### PR TITLE
RF2 ESC and PRC new vs replacement all tests passing

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/RF2/RF2_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/RF2/RF2_ESC_calculation.yaml
@@ -57,6 +57,32 @@
         12
       ]
 
+- name: test Baseline EEI by new install versus replacement
+  period: 2022
+  absolute_error_margin: 0.1
+  input: 
+    RF2_product_class:
+      [
+        product_class_five,
+        product_class_five
+      ]
+    RF2_duty_class:
+      [
+        normal_duty,
+        normal_duty
+      ]
+    RF2_replacement_activity:
+      [
+        true, #activity is a replacement
+        false #activity is a new installation
+      ]
+  output:
+    RF2_baseline_EEI:
+      [
+        100,
+        77
+      ]
+
 - name: test baseline_peak_adjustment_factor
   period: 2022
   absolute_error_margin: 0

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/RF2/RF2_PRC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/RF2/RF2_PRC_calculation.yaml
@@ -117,3 +117,29 @@
         388,
         91
       ]
+
+- name: test RF2 PRC not eligible on new installation
+  period: 2022
+  absolute_error_margin: 0.1
+  input: 
+    RF2_peak_demand_reduction_capacity:
+      [
+        100,
+        100
+      ]
+    RF2_network_loss_factor:
+      [
+        1.05,
+        1.05
+      ]
+    RF2_replacement_activity:
+      [
+        True,  #activity is a replacement
+        False  #activity is a new installation
+      ]
+  output:
+    RF2_PRC_calculation:
+      [
+        1050,
+        0
+      ]

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS2/SYS2_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS2/SYS2_ESC_calculation.yaml
@@ -58,7 +58,7 @@
         15,
         15
       ]
-    SYS2_Replacement_Activity:
+    SYS2_replacement_activity:
       [
         False, #activity is a new installation
         True   #activity is a replacement

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS2/SYS2_PRC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS2/SYS2_PRC_calculation.yaml
@@ -102,7 +102,7 @@
         1.05,
         1.05
       ]
-    SYS2_Replacement_Activity:
+    SYS2_replacement_activity:
       [
         False, #activity is a new installation
         True   #activity is a replacement

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/RF2/certificate_estimation/RF2_ESC_variables.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/RF2/certificate_estimation/RF2_ESC_variables.py
@@ -44,7 +44,7 @@ class RF2_af(Variable):
   def formula(buildings, period, parameters):
     product_class = buildings('RF2_product_class', period)
     duty_type = buildings('RF2_duty_class', period)
-    new_equipment = buildings('RF2_new_equipment', period)
+    new_equipment = buildings('RF2_replacement_activity', period)
     
     af = np.select(
       [ 
@@ -67,17 +67,17 @@ class RF2_baseline_EEI(Variable):
   def formula(buildings, period, parameters):
     product_class = buildings('RF2_product_class', period)
     duty_type = buildings('RF2_duty_class', period)
-    new_equipment = buildings('RF2_new_equipment', period)
+    replacement_activity = buildings('RF2_replacement_activity', period)
 
     baseline_EEI = np.select(
       [ 
-        new_equipment, 
-        np.logical_not(new_equipment)
+        replacement_activity,
+        np.logical_not(replacement_activity)
       ],
       [ 
-        parameters(period).ESS.HEAB.table_F1_1_1['baseline_EEI'][product_class][duty_type],
-        parameters(period).PDRS.refrigerated_cabinets.table_RF2_1['baseline_EEI'][product_class][duty_type]
-       ]
+        parameters(period).PDRS.refrigerated_cabinets.table_RF2_1['baseline_EEI'][product_class][duty_type],
+        parameters(period).ESS.HEAB.table_F1_1_1['baseline_EEI'][product_class][duty_type]
+      ]
     )    
     return baseline_EEI
 
@@ -270,15 +270,14 @@ class RF2_PDRS__postcode(Variable):
         }
 
 
-class RF2_new_equipment(Variable):  
+class RF2_replacement_activity(Variable):  
     value_type = bool
     default_value = True
     entity = Building
     definition_period = ETERNITY
-    label = 'New or Used equipment'
     metadata = {
-        'variable-type': 'user-input',
-        'label' : 'New or Used equipment',
-        'display_question' : 'Is the end-user equipment a new commercial refrigerated cabinet?',
+        'variable-type' : 'user-input',
+        'label' : 'Replacement or new installation activity',
+        'display_question' : 'Is the activity a replacement of existing equipment?',
         'sorting' : 3
         }

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2/certificate_estimation/SYS2_ESC_calculation.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2/certificate_estimation/SYS2_ESC_calculation.py
@@ -94,7 +94,7 @@ class SYS2_ESC_calculation(Variable):
         electricity_savings = buildings('SYS2_electricity_savings', period)
         electricity_certificate_conversion_factor = 1.06
         #there is no gas option for this activity
-        replacement_activity = buildings('SYS2_Replacement_Activity', period)
+        replacement_activity = buildings('SYS2_replacement_activity', period)
         
         SYS2_eligible_ESCs = np.select(
             [

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2/certificate_estimation/SYS2_ESC_variables.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2/certificate_estimation/SYS2_ESC_variables.py
@@ -23,7 +23,7 @@ class SYS2_PDRS__postcode(Variable):
         }
 
 
-class SYS2_Replacement_Activity(Variable):
+class SYS2_replacement_activity(Variable):
     value_type = bool
     default_value = True
     entity = Building

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2/certificate_estimation/SYS2_PRC_calculation.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2/certificate_estimation/SYS2_PRC_calculation.py
@@ -57,7 +57,7 @@ class SYS2_PRC_calculation(Variable):
         peak_demand_capacity = buildings('SYS2_peak_demand_reduction_capacity', period)
         network_loss_factor = buildings('SYS2_network_loss_factor', period)
         kw_to_0_1kw = 10
-        replacement_activity = buildings('SYS2_Replacement_Activity', period)
+        replacement_activity = buildings('SYS2_replacement_activity', period)
 
         SYS2_eligible_PRCs = np.select(
             [


### PR DESCRIPTION
RF2 ESC and PRC activities updated. (Also an update on variable name SYS2) All tests passing.
Notes: 
• on RF2, both install and replacement activities are eligible (but use different tables for baseline EEI)
• on PRCs, only replacement is eligible (I am setting the eligible option as default for each activity)
