### PR TITLE
Removed minimum savings requirement - all tests passing

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/WH1/WH1_installation_final_activity_eligibility.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/WH1/WH1_installation_final_activity_eligibility.yaml
@@ -82,13 +82,6 @@
         true,
         true
       ]
-    WH1_minimum_savings:
-      [
-        true,
-        true,
-        true,
-        true  
-      ]
     WH1_equipment_certified_by_storage_volume:
       [
         true,

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/WH1/activity_eligibility/WH1_activity_eligibility_parameters.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/WH1/activity_eligibility/WH1_activity_eligibility_parameters.py
@@ -104,20 +104,6 @@ class WH1_scheme_admin_approved(Variable):
     }
 
 
-class WH1_minimum_savings(Variable):
-    value_type = bool
-    entity = Building
-    default_value = True
-    definition_period = ETERNITY
-    metadata = {  
-      'display_question' : 'Has the model met the 60% minimum annual energy savings requirement?',
-      'sorting' : 9,
-      'eligibility_clause' : """In PDRS WH1 Equipment Requirements Clause 2 it states that the installed End-User Equipment must achieve minimum annual energy savings, when determined in accordance with the modelling procedure published by the Scheme Administrator, of: <br />
-      a. 60% when modelled in climate zone HP3-AU if the Site is in BCA Climate Zone 2, 3, 4, 5 or 6; <br />
-      b. 60% when modelled in climate zone HP5-AU if the Site is in BCA Climate Zone 7 or 8."""
-    }
-
-
 class WH1StorageVolume(Enum):
     less_than_or_equal_to_700_L = 'Less than or equal to 700 litres'
     more_than_700_L = 'More than 700 litres'

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/WH1/activity_eligibility/WH1_eligibility.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/WH1/activity_eligibility/WH1_eligibility.py
@@ -25,7 +25,6 @@ class WH1_installation_replacement_final_activity_eligibility(Variable):
         not_installed_class_1_or_4 = buildings('WH1_building_BCA_not_class_1_or_4', period)
         air_source_heat_pump = buildings('WH1_air_source_heat_pump', period)
         scheme_admin_approved = buildings('WH1_scheme_admin_approved', period)
-        minimum_savings_met = buildings('WH1_minimum_savings', period)
         storage_volume_certified = buildings('WH1_equipment_certified_by_storage_volume', period)
         
 
@@ -42,7 +41,7 @@ class WH1_installation_replacement_final_activity_eligibility(Variable):
         ])
 
         end_formula = ( installation_or_replacement * qualified_removal_install * equipment_installed *
-                        np.logical_not(not_installed_class_1_or_4) * air_source_heat_pump * scheme_admin_approved *
-                        minimum_savings_met * storage_volume_certified )
+                        np.logical_not(not_installed_class_1_or_4) * air_source_heat_pump * scheme_admin_approved 
+                        * storage_volume_certified )
 
         return end_formula


### PR DESCRIPTION
We don't need to ask if the equipment meets the 60% minimum savings target, because if it is on the registry, it is an approved product (which means - it does meet the target). 