### PR TITLE
Fixed Baseline AEER HEER tests

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS/ESS_HEER/ESS_HEER_AC/ESS_HEER_AC_energy_savings.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS/ESS_HEER/ESS_HEER_AC/ESS_HEER_AC_energy_savings.yaml
@@ -52,7 +52,7 @@
     ]
     ESS_HEER_AC_replace_electricity_savings: [
                                       6.0693903,
-                                      18.384142,
+                                      18.174957,
                                       56.373688,
                                       116.300575
     ]

--- a/openfisca_nsw_safeguard/tests/ESS/ESS_HEER/ESS_HEER_AC/ESS_HEER_AC_replace_cooling_and_heating_energy_use.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS/ESS_HEER/ESS_HEER_AC/ESS_HEER_AC_replace_cooling_and_heating_energy_use.yaml
@@ -22,7 +22,7 @@
   output: 
     ESS_HEER_AC_replace_reference_cooling_annual_energy_use: [
                                                     1147.7478,
-                                                    3064.6047,
+                                                    3043.686,
                                                     9100,
                                                     18530.908
                                                     ]
@@ -134,7 +134,7 @@
   output: 
     ESS_HEER_AC_replace_reference_cooling_annual_energy_use: [
                                                     386.48648,
-                                                    1031.9587,
+                                                    1024.9147,
                                                     3064.2856,
                                                     6240
                                                     ]
@@ -162,7 +162,7 @@
   output: 
     ESS_HEER_AC_replace_reference_cooling_annual_energy_use: [
                                                     256.75674,
-                                                    685.567,
+                                                    680.8874
                                                     2035.7142,
                                                     4145.4546
                                                     ]
@@ -274,7 +274,7 @@
   output: 
     ESS_HEER_AC_replace_reference_cooling_annual_energy_use: [
                                                     1147.7478,
-                                                    3064.6047,
+                                                    3043.686,
                                                     9100,
                                                     18530.908
                                                     ]
@@ -302,7 +302,7 @@
   output: 
     ESS_HEER_AC_replace_reference_cooling_annual_energy_use: [
                                                     386.48648,
-                                                    1031.9587,
+                                                    1024.9147,
                                                     3064.2856,
                                                     6240
                                                     ]
@@ -330,7 +330,7 @@
   output: 
     ESS_HEER_AC_replace_reference_cooling_annual_energy_use: [
                                                     256.75674,
-                                                    685.567,
+                                                    680.8874,
                                                     2035.7142,
                                                     4145.4546
                                                     ]


### PR DESCRIPTION
This set of tests was broken when we updated the D16.3 table with the Baseline AEER value for AC capacity between 4-10kW.