### PR TITLE
WIP Product EEI throwing inf

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/RF2/RF2_PRC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/RF2/RF2_PRC_calculation.yaml
@@ -275,3 +275,45 @@
         1.05,
         0
       ]
+
+- name: test PRCs CDSCake cds1200cake
+  period: 2022
+  absolute_error_margin: 0.5
+  input:
+    RF2_get_network_loss_factor_by_postcode: 
+      [
+        1.04 #CDSCake cds1200cake
+      ]
+    RF2_PDRS__postcode: 
+      [
+        2076
+      ]
+    RF2_duty_class:
+      [
+        normal_duty
+      ]
+    RF2_product_EEI:
+      [
+        0 #not eligible
+      ]
+    RF2_product_class:
+      [
+        Class 10
+      ]
+    RF2_replacement_activity:
+      [
+        true
+      ]
+    RF2_total_display_area:
+      [
+        1.863
+      ]
+    RF2_total_energy_consumption:
+      [
+        16.17
+      ]
+  output: 
+    RF2_PRC_calculation: 
+      [
+        0
+      ]

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/RF2/certificate_estimation/RF2_PRC_calculation.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/RF2/certificate_estimation/RF2_PRC_calculation.py
@@ -21,7 +21,14 @@ class RF2_baseline_input_power(Variable):
       baseline_EEI = buildings('RF2_baseline_EEI', period)
       product_EEI = buildings('RF2_product_EEI', period)
       
-      baseline_input_power = np.multiply((total_energy_consumption * af), (baseline_EEI / product_EEI) / 24)
+      baseline_input_power = np.select(
+          [
+            product_EEI == 0, product_EEI != 0
+          ], 
+         [
+              0, np.multiply((total_energy_consumption * af), (baseline_EEI / product_EEI) / 24)
+          ])
+      
       return baseline_input_power
   
   
@@ -98,7 +105,6 @@ class RF2_PRC_calculation(Variable):
         replacement_activity = buildings('RF2_replacement_activity', period)
         EEI_eligible_replacement = buildings('RF2_product_EEI_PRC_replacement_eligibility', period)
         EEI_eligible_install = buildings('RF2_product_EEI_ESC_install_eligibility', period)
-
         RF2_eligible_PRCs = np.select(
             [
                 replacement_activity * EEI_eligible_replacement,
@@ -112,7 +118,7 @@ class RF2_PRC_calculation(Variable):
                 0,
                 0
             ])
-
+        
         result_to_return = np.select(
             [
                 RF2_eligible_PRCs <= 0, RF2_eligible_PRCs > 0


### PR DESCRIPTION
WIP this is partly looked at - I think the problem is because we are pulling RF2_product_EEI into a bool for eligibility and then also assigning a value to it for the baseline input power calculation. I'm only partway through and have left the prints in. There is also one failing test in RF2 yaml file.