### PR TITLE
negative numbers on savings adjusted to zero all tests passing

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS1/SYS1_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS1/SYS1_ESC_calculation.yaml
@@ -194,7 +194,7 @@
   output:  
     SYS1_energy_savings:
       [
-        -30369.238,
+        0,
         41.501
       ]
 

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS1/SYS1_PRC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS1/SYS1_PRC_calculation.yaml
@@ -126,7 +126,7 @@
     SYS1_peak_demand_annual_savings:
       [
         1.452,
-        -101.455
+        0
       ]
  
 - name: test SYS1 PRC calculation simple

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS1/certificate_estimation/SYS1_ESC_calculation.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS1/certificate_estimation/SYS1_ESC_calculation.py
@@ -407,7 +407,14 @@ class SYS1_energy_savings(Variable):
         temp_calc_3 = (load_utilisation_factor * asset_life * ( 8760 / 1000 ))
 
         annual_energy_savings = ((temp_calc_1 - temp_calc_2) * temp_calc_3)
-        return annual_energy_savings
+
+        annual_savings_return = np.select([
+            annual_energy_savings <= 0, annual_energy_savings > 0
+        ], [
+            0, annual_energy_savings
+        ])
+        
+        return annual_savings_return
 
 
 class SYS1_electricity_savings(Variable):

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS1/certificate_estimation/SYS1_PRC_calculation.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS1/certificate_estimation/SYS1_PRC_calculation.py
@@ -253,8 +253,15 @@ class SYS1_peak_demand_annual_savings(Variable):
         temp2 = input_power * baseline_peak_adjustment_factor
 
         peak_demand_annual_savings = ((temp1 - temp2) * firmness_factor) * summer_peak_demand_reduction_duration
-        return peak_demand_annual_savings
-    
+        
+        peak_demand_annual_savings_return = np.select([
+                peak_demand_annual_savings <= 0, peak_demand_annual_savings > 0
+            ], [
+                0, peak_demand_annual_savings
+            ])
+        
+        return peak_demand_annual_savings_return
+        
 
 class SYS1_peak_demand_reduction_capacity(Variable):
     value_type = float


### PR DESCRIPTION
 this PR adds in the if -< 0 code for SYS1 annual savings and peak demand