### PR TITLE
WH2 savings updates all tests passing

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/WH2_test/WH2_test_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/WH2_test/WH2_test_ESC_calculation.yaml
@@ -130,44 +130,51 @@
       [
         20,
         100,
-        20
+        20,
+        81 #Quantum 150-08AC6-290
       ]
     WH2_test_HP_elec:
       [
         10,
         3,
-        20
+        20,
+        9.54
       ]
     WH2_test_HP_capacity_factor:
       [
         20,
         36,
-        50
+        50,
+        3.1
       ]
     WH2_test_WH_capacity_factor:
       [
         25,
         6,
-        2
+        2,
+        6
       ]
     WH2_test_HP_gas:
       [
         20,
         30,
-        50
+        50,
+        0
       ]
     WH2_test_old_equipment:
       [
         electric_water_boiler_heater,
         electric_water_boiler_heater,
+        gas_water_boiler_heater,
         gas_water_boiler_heater
       ]
   output:
     WH2_test_energy_savings:
       [
-        -76.88,
+        0, #negative value
         0.95,
-        -8.16
+        0, #negative value
+        87.04
       ]
 
 - name: test WH2_test ESC calculation

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/WH2_test/WH2_test_PRC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/WH2_test/WH2_test_PRC_calculation.yaml
@@ -1,45 +1,83 @@
+- name: test WH2_test annual ESS savings
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    WH2_test_com_peak_load:
+      [
+        20,
+        100,
+        20,
+        81 #Quantum 150-08AC6-290
+      ]
+    WH2_test_annual_energy_savings:
+      [
+        50,
+        50,
+        60,
+        66
+      ]
+  output:
+    WH2_test_peak_demand_annual_savings:
+      [
+        8.856,
+        44.28,
+        9.964799,
+        43.05
+      ]
+
+
 - name: test WH2 test PRC calculation
   period: 2022
   absolute_error_margin: 0.5
   input:
     WH2_test_HP_capacity_factor:
       [
-        3.26
+        3.26,
+        3.1
       ]
     WH2_test_HP_elec:
       [
-        9.39
+        9.39,
+        9.54
       ]
     WH2_test_HP_gas:
       [
+        0,
         0
       ]
     WH2_test_PDRS__postcode:
       [
-        2017
+        2017,
+        2024
       ]
     WH2_test_WH_capacity_factor: 
       [
-        1
+        1,
+        6
       ]
     WH2_test_annual_energy_savings:
       [
-        71.8
+        71.8,
+        66
       ]
     WH2_test_com_peak_load:
       [
-        96
+        96,
+        81
       ]
     WH2_test_old_equipment:
       [
+        gas_water_boiler_heater,
         gas_water_boiler_heater
       ]
     WH2_test_replacement_activity:
       [
+        true,
         true
       ]
   output:
     WH2_test_PRC_calculation:
       [
-        562.50
+        562.50,
+        447.73
       ]

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/WH2_test/certificate_estimation/WH2_ESC_calculation.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/WH2_test/certificate_estimation/WH2_ESC_calculation.py
@@ -189,9 +189,17 @@ class WH2_test_energy_savings(Variable):
             (- HP_elec) * capacity_factor * (lifetime / 3.6),
             (ref_elec - HP_elec) * capacity_factor * (lifetime / 3.6)
         ])
-
+      
         annual_energy_savings = deemed_electricity_savings + deemed_gas_savings
-        return annual_energy_savings
+    
+        annual_savings_return = np.select([
+            annual_energy_savings <= 0, annual_energy_savings > 0
+        ], 
+	    [
+            0, annual_energy_savings
+        ])
+        
+        return annual_savings_return
 
 
 class WH2_test_electricity_savings(Variable):

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/WH2_test/certificate_estimation/WH2_PRC_calculation.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/WH2_test/certificate_estimation/WH2_PRC_calculation.py
@@ -89,11 +89,25 @@ class WH2_test_peak_demand_annual_savings(Variable):
         firmness_factor = parameters(period).PDRS.table_A6_firmness_factor['firmness_factor']['WH1']
 
         #peak demand savings capacity
-        summer_peak_demand_reduction_duration = 6
-        peak_demand_annual_savings = ((baseline_input_power * baseline_peak_adjustment_factor) - (input_power * peak_adjustment_factor * firmness_factor)) * summer_peak_demand_reduction_duration
+        peak_demand_savings_capacity = ((baseline_input_power * baseline_peak_adjustment_factor) - (input_power * peak_adjustment_factor) * firmness_factor)
         
-        return peak_demand_annual_savings
+        #lifetime
+        lifetime = parameters(period).ESS.HEAB.table_F16_1['lifetime']
         
+        #peak demand reduction capacity
+        summer_peak_duration = 6
+
+        peak_demand_annual_savings = peak_demand_savings_capacity * summer_peak_duration * lifetime
+
+        peak_demand_annual_savings_return = np.select([
+                peak_demand_annual_savings <= 0, peak_demand_annual_savings > 0
+            ], 
+	        [
+                0, peak_demand_annual_savings
+            ])
+        
+        return peak_demand_annual_savings_return
+
 
 class WH2_test_peak_demand_reduction_capacity(Variable):
     value_type = float


### PR DESCRIPTION
this code update has:
• the added savings for both energy and peak demand savings
• negative value = 0
• tests for a gas replacement hot water activity