### PR TITLE
Sys2 eligibility clause fix

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS2_PDRSAug24/SYS2_PDRSAug24_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS2_PDRSAug24/SYS2_PDRSAug24_ESC_calculation.yaml
@@ -1,129 +1,129 @@
-# - name: test SYS2 baseline PAEC
-#   period: 2024
-#   absolute_error_margin: 0
-#   input:
-#     SYS2_PDRSAug24_nameplate_input_power:
-#       [
-#         900,
-#         1400,
-#         2000,
-#         3500
-#       ]
-#   output:
-#     SYS2_PDRSAug24_PAEC_baseline:
-#       [
-#         1300,
-#         1500,
-#         1700,
-#         2000
-#       ]
+- name: test SYS2 baseline PAEC
+  period: 2024
+  absolute_error_margin: 0
+  input:
+    SYS2_PDRSAug24_nameplate_input_power:
+      [
+        900,
+        1400,
+        2000,
+        3500
+      ]
+  output:
+    SYS2_PDRSAug24_PAEC_baseline:
+      [
+        1300,
+        1500,
+        1700,
+        2000
+      ]
 
-# - name: test SYS2 deemed electricity savings
-#   period: 2024
-#   absolute_error_margin: 0.1
-#   input:
-#     SYS2_PDRSAug24_projected_annual_energy_consumption:
-#       [
-#         50,
-#         600,
-#         400,
-#         657,
-#         789,
-#         2000
-#       ]
-#     SYS2_PDRSAug24_PAEC_baseline:
-#       [
-#         100,
-#         1500,
-#         1700,
-#         2000,
-#         1700,
-#         1500
-#       ]
-#   output:
-#     SYS2_PDRSAug24_deemed_activity_electricity_savings:
-#       [
-#         0.5,
-#         9,
-#         13,
-#         13.43,
-#         9.11,
-#         -5
-#       ]
+- name: test SYS2 deemed electricity savings
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    SYS2_PDRSAug24_projected_annual_energy_consumption:
+      [
+        50,
+        600,
+        400,
+        657,
+        789,
+        2000
+      ]
+    SYS2_PDRSAug24_PAEC_baseline:
+      [
+        100,
+        1500,
+        1700,
+        2000,
+        1700,
+        1500
+      ]
+  output:
+    SYS2_PDRSAug24_deemed_activity_electricity_savings:
+      [
+        0.5,
+        9,
+        13,
+        13.43,
+        9.11,
+        -5
+      ]
 
-# - name: test SYS2 annual energy savings
-#   period: 2024
-#   absolute_error_margin: 0.1
-#   input:
-#     SYS2_PDRSAug24_nameplate_input_power:
-#       [
-#         0,    #baseline PAEC 1300
-#         1000, #baseline PAEC 1300
-#         1567, #baseline PAEC 1700
-#         1001, #baseline PAEC 1500
-#         2000, #baseline PAEC 1700
-#         2001, #baseline PAEC 2000
-#         1999, #baseline PAEC 1700
-#         1350  #baseline PAEC 1500
-#       ]
-#     SYS2_PDRSAug24_projected_annual_energy_consumption:
-#       [
-#         0,
-#         10,
-#         50,
-#         600,
-#         400,
-#         657,
-#         789,
-#         2000
-#       ]
-#     SYS2_PDRSAug24_PDRS__postcode:
-#       [
-#         2024,
-#         2024,
-#         2024,
-#         2800, #rnf 1.03
-#         2800,
-#         2800,
-#         2024,
-#         2024
-#       ]
-#   output:
-#     SYS2_PDRSAug24_energy_savings:
-#       [
-#         13,
-#         12.9,
-#         16.5,
-#         9.27,
-#         13.39,
-#         13.83,
-#         9.11,
-#         0
-#       ]
+- name: test SYS2 annual energy savings
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    SYS2_PDRSAug24_nameplate_input_power:
+      [
+        0,    #baseline PAEC 1300
+        1000, #baseline PAEC 1300
+        1567, #baseline PAEC 1700
+        1001, #baseline PAEC 1500
+        2000, #baseline PAEC 1700
+        2001, #baseline PAEC 2000
+        1999, #baseline PAEC 1700
+        1350  #baseline PAEC 1500
+      ]
+    SYS2_PDRSAug24_projected_annual_energy_consumption:
+      [
+        0,
+        10,
+        50,
+        600,
+        400,
+        657,
+        789,
+        2000
+      ]
+    SYS2_PDRSAug24_PDRS__postcode:
+      [
+        2024,
+        2024,
+        2024,
+        2800, #rnf 1.03
+        2800,
+        2800,
+        2024,
+        2024
+      ]
+  output:
+    SYS2_PDRSAug24_energy_savings:
+      [
+        13,
+        12.9,
+        16.5,
+        9.27,
+        13.39,
+        13.83,
+        9.11,
+        0
+      ]
 
-# - name: test SYS2 electricity savings
-#   period: 2024
-#   absolute_error_margin: 0.5
-#   input:
-#     SYS2_PDRSAug24_deemed_activity_electricity_savings:
-#       [
-#         6,
-#         24,
-#         0
-#       ]
-#     SYS2_PDRSAug24_PDRS__postcode:
-#       [
-#         2043, #rnf 1
-#         2321, #rnf 1.03
-#         2074  #rnf 1
-#       ]
-#   output:
-#     SYS2_PDRSAug24_electricity_savings:
-#       [
-#         6,
-#         24.72,
-#         0
-#       ]
+- name: test SYS2 electricity savings
+  period: 2024
+  absolute_error_margin: 0.5
+  input:
+    SYS2_PDRSAug24_deemed_activity_electricity_savings:
+      [
+        6,
+        24,
+        0
+      ]
+    SYS2_PDRSAug24_PDRS__postcode:
+      [
+        2043, #rnf 1
+        2321, #rnf 1.03
+        2074  #rnf 1
+      ]
+  output:
+    SYS2_PDRSAug24_electricity_savings:
+      [
+        6,
+        24.72,
+        0
+      ]
     
 - name: test SYS2 ESC calculation
   period: 2024

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2_PDRSAug24/activity_eligibility/SYS2_PDRSAug24_activity_eligibility_parameters.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2_PDRSAug24/activity_eligibility/SYS2_PDRSAug24_activity_eligibility_parameters.py
@@ -149,7 +149,7 @@ class SYS2_PDRSAug24_equipment_registered_in_GEMS(Variable):
     metadata = {
         'display_question' : 'Is the installed End-User equipment a registered product on the GEMS registry under GEMS (Swimming Pool Pump-units) Determination 2021?',
         'sorting' : 7,
-        'eligibility_clause' : """In ESS D5 Equipment Requirements Clause 1 it states that the new End-User Equipment must be listed as part of a labelling scheme determined in accordance with the Equipment Energy Efficiency (E3) Committee's Voluntary Energy Rating Labelling Program for Swimming Pool Pump-units: Rules for Participation, April 2010, or be a registered product in the GEMS Registry as complying with the Greenhouse and Energy Minimum Standards (Swimming Pool Pump-units) Determination 2021."""
+        'eligibility_clause' : """In ESS D5 Equipment Requirements Clause 1 it states that the new or replacement End-User Equipment must be registered in the GEMS Registry as complying with the Greenhouse and Energy Minimum Standards (Swimming Pool Pump-units) Determination 2021."""
     }
 
 


### PR DESCRIPTION
This PR updates the eligibility clause on SYS2_PDRSAug24_equipment_registered_in_GEMS and removes the comments from the test (which were accidentally left in). All tests passing.