### PR TITLE
[DG22-1643] BESS2 eligibility

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/BESS2_V5Nov24/BESS2_V5Nov24_PRC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/BESS2_V5Nov24/BESS2_V5Nov24_PRC_calculation.yaml
@@ -1,0 +1,103 @@
+- name: Test BESS2 demand response component
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    BESS2_V5Nov24_usable_battery_capacity:
+      [
+        1,
+        5,
+        0.1
+      ]
+  output:
+    BESS2_V5Nov24_demand_response_component:
+      [
+        0.0647,
+        0.3235,
+        0.00647
+      ]
+
+- name: Test BESS2 peak demand response capacity
+  period: 2024
+  absolute_error_margin: 0.1
+  input:   
+    BESS2_V5Nov24_demand_response_component:
+      [
+        1,
+        6.5,
+        0.5
+      ]
+  output:
+    BESS2_V5Nov24_peak_demand_response_capacity:
+      [
+        1,
+        6.5,
+        0.5
+      ]
+
+- name: Test BESS2 peak demand annual savings
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    BESS2_V5Nov24_usable_battery_capacity:
+      [
+        27,
+        17,
+        49,
+        8
+      ]
+  output:
+    BESS2_V5Nov24_peak_demand_annual_savings:
+      [
+        31.4442,
+        19.7982,
+        57.0654,
+        9.3168
+      ]
+
+- name: Test BESS2 peak demand reduction capacity
+  period: 2024
+  absolute_error_margin: 0.1
+  input:   
+    BESS2_V5Nov24_peak_demand_response_capacity:
+      [
+        15,
+        7.5,
+        19.8
+      ]
+  output:
+    BESS2_V5Nov24_peak_demand_reduction_capacity:
+      [
+        270,
+        135,
+        356.4
+      ]
+
+- name: Test BESS2 PRC calculation
+  period: 2024
+  absolute_error_margin: 0.1
+  input:
+    BESS2_V5Nov24_peak_demand_reduction_capacity:
+      [
+        1,
+        5,
+        9
+      ]
+    BESS2_V5Nov24_get_network_loss_factor_by_postcode:
+      [
+        1.04,
+        1.04,
+        1.04
+      ]
+    BESS2_V5Nov24_installation_activity:
+      [
+        true,
+        true,
+        False
+      ]
+  output:
+    BESS2_V5Nov24_PRC_calculation:
+      [
+        10.4,
+        52,
+        0
+      ]

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/BESS2_V5Nov24/BESS2_V5Nov24_installation_final_activity_eligibility.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/BESS2_V5Nov24/BESS2_V5Nov24_installation_final_activity_eligibility.yaml
@@ -1,6 +1,5 @@
-- name:
-    Test BESS2 final formula installation eligibility
-  period: 2022
+- name: Test BESS2 final formula installation eligibility
+  period: 2024
   absolute_error_margin: 0
   input:
     BESS2_V5Nov24_demand_response_contract:
@@ -14,7 +13,11 @@
         True,
         True,
         True,
-        True
+        True,
+        True,
+        True,
+        True,
+        False
       ]
     BESS2_V5Nov24_existing_solar_battery:
       [
@@ -27,7 +30,11 @@
         True,
         True,
         True,
-        True
+        True,
+        True,
+        True,
+        True,
+        False
       ]
     BESS2_V5Nov24_solar_panels_existing_address:
       [
@@ -40,7 +47,11 @@
         True,
         True,
         True,
-        True
+        True,
+        True,
+        True,
+        True,
+        False
       ]
     BESS2_V5Nov24_life_support_equipment:
       [
@@ -53,7 +64,28 @@
         True,
         True,
         True,
-        True
+        True,
+        True,
+        True,
+        True,
+        False
+      ]
+    BESS2_V5Nov24_engaged_ACP:
+      [
+        True,
+        True,
+        True,
+        True,
+        True,
+        False, #not eligible
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        False
       ]
     BESS2_V5Nov24_battery_capacity:
       [
@@ -62,13 +94,17 @@
         True,
         True,
         True,
+        True,
         False, #not eligible
         True,
         True,
         True,
-        True
+        True,
+        True,
+        True,
+        False
       ]
-    BESS2_V5Nov24_implementation_date:
+    BESS2_V5Nov24_length_battery_warranty:
       [
         True,
         True,
@@ -76,10 +112,48 @@
         True,
         True,
         True,
+        True,
         False, #not eligible
         True,
         True,
-        True
+        True,
+        True,
+        True,
+        False
+      ]
+    BESS2_V5Nov24_temperature_range_warranty:
+      [
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        False, #not eligible
+        True,
+        True,
+        True,
+        True,
+        False
+      ]
+    BESS2_V5Nov24_minimum_throughput_warranty_before_April_2026:
+      [
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        False, #not eligible
+        True,
+        True,
+        True,
+        False
       ]
     BESS2_V5Nov24_internet_connectable:
       [
@@ -90,9 +164,13 @@
         True,
         True,
         True,
+        True,
+        True,
+        True,
         False, #not eligible
         True,
-        True
+        True,
+        False
       ]
     BESS2_V5Nov24_battery_controllable_third_party:
       [
@@ -103,27 +181,35 @@
         True,
         True,
         True,
+        True,
+        True,
+        True,
+        True,
         False, #not eligible
         True,
-        True
+        False
       ]
     BESS2_V5Nov24_approved_battery_list:
       [
         True,
         True,
         True,
+        True, 
+        True,
+        True,
+        True,
         True,
         True,
         True,
         True,
         True,
         False, #not eligible
-        True
+        False
       ]
   output:
     BESS2_V5Nov24_installation_final_activity_eligibility:
       [
-        True,
+        True,  #all true
         False,
         False,
         False,
@@ -132,5 +218,9 @@
         False,
         False,
         False,
-        True
+        False,
+        False,
+        False,
+        False,
+        False  #all false
       ]

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/BESS2_V5Nov24/BESS2_V5Nov24_installation_final_activity_eligibility.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/BESS2_V5Nov24/BESS2_V5Nov24_installation_final_activity_eligibility.yaml
@@ -1,0 +1,136 @@
+- name:
+    Test BESS2 final formula installation eligibility
+  period: 2022
+  absolute_error_margin: 0
+  input:
+    BESS2_V5Nov24_demand_response_contract:
+      [
+        True,
+        False, #not eligible
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True
+      ]
+    BESS2_V5Nov24_existing_solar_battery:
+      [
+        True,
+        True,
+        False, #not eligible
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True
+      ]
+    BESS2_V5Nov24_solar_panels_existing_address:
+      [
+        True,
+        True,
+        True,
+        False, #not eligible
+        True,
+        True,
+        True,
+        True,
+        True,
+        True
+      ]
+    BESS2_V5Nov24_life_support_equipment:
+      [
+        True,
+        True,
+        True,
+        True,
+        False, #not eligible
+        True,
+        True,
+        True,
+        True,
+        True
+      ]
+    BESS2_V5Nov24_battery_capacity:
+      [
+        True,
+        True,
+        True,
+        True,
+        True,
+        False, #not eligible
+        True,
+        True,
+        True,
+        True
+      ]
+    BESS2_V5Nov24_implementation_date:
+      [
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        False, #not eligible
+        True,
+        True,
+        True
+      ]
+    BESS2_V5Nov24_internet_connectable:
+      [
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        False, #not eligible
+        True,
+        True
+      ]
+    BESS2_V5Nov24_battery_controllable_third_party:
+      [
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        False, #not eligible
+        True,
+        True
+      ]
+    BESS2_V5Nov24_approved_battery_list:
+      [
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        False, #not eligible
+        True
+      ]
+  output:
+    BESS2_V5Nov24_installation_final_activity_eligibility:
+      [
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True
+      ]

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS1_V5Nov24/activity_eligibility/BESS1_V5Nov24_activity_eligibility_parameters.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS1_V5Nov24/activity_eligibility/BESS1_V5Nov24_activity_eligibility_parameters.py
@@ -63,7 +63,7 @@ class BESS1_V5Nov24_minimum_payment(Variable):
     metadata = {
         'display_question' : 'Are you aware that you are required to make a minimum payment towards the cost of your upgrade?',
         'sorting' : 5,
-        'eligibility_clause' : """In PDRS Clause 8.3.1 it states that the Accredited Certificate Provider has evidence satisfactory to the Scheme Administrator that the Purchaser has paid for the Implementation, assessment and other associated works carried out at the Site a Net Amount of at least $200 (excluding GST) for each item of End-User Equipment installed as part of an Implementation using Activity Definition BESS1"""
+        'eligibility_clause' : """In PDRS Clause 8.3.1 it states that the Accredited Certificate Provider has evidence satisfactory to the Scheme Administrator that the Purchaser has paid for the Implementation, assessment and other associated works carried out at the Site a Net Amount of at least $200 (excluding GST) for each item of End-User Equipment installed as part of an Implementation using Activity Definition BESS1."""
     }
 
 
@@ -111,7 +111,7 @@ class BESS1_V5Nov24_temperature_range_warranty(Variable):
     metadata = {
         'display_question' : 'Does the warranty define the normal use conditions of the battery as a minimum ambient temperature range of -10°C to 50°C?',
         'sorting' : 9,
-        'eligibility_clause' : """In PDRS BESS1 Equipment Requirements Clause 5 it states that each End-User Equipment warranty must define the normal use conditions during the operation of the End-User Equipment as not being less than a minimum ambient temperature range of -10°C to 50°C"""
+        'eligibility_clause' : """In PDRS BESS1 Equipment Requirements Clause 5 it states that each End-User Equipment warranty must define the normal use conditions during the operation of the End-User Equipment as not being less than a minimum ambient temperature range of -10°C to 50°C."""
     }
 
 
@@ -123,7 +123,7 @@ class BESS1_V5Nov24_minimum_throughput_warranty_before_April_2026(Variable):
     metadata = {
         'display_question' : 'Does the warranty include a minimum throughput of 2.8MWh per kWh of usable capacity?',
         'sorting' : 10,
-        'eligibility_clause' : """In PDRS BESS1 Equipment Requirements Clause 5 it states that each End-User Equipment warranty must define the normal use conditions during the operation of the End-User Equipment as not being less than a minimum warranted cumulative energy throughput equivalent to 2.8 MWh per kWh of Usable Battery Capacity where the Implementation Date is before 1 April 2026"""
+        'eligibility_clause' : """In PDRS BESS1 Equipment Requirements Clause 5 it states that each End-User Equipment warranty must define the normal use conditions during the operation of the End-User Equipment as not being less than a minimum warranted cumulative energy throughput equivalent to 2.8 MWh per kWh of Usable Battery Capacity where the Implementation Date is before 1 April 2026."""
     }
 
 

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_activity_eligibility_parameters.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_activity_eligibility_parameters.py
@@ -1,0 +1,114 @@
+import numpy as np
+from openfisca_core.variables import Variable
+from openfisca_core.periods import ETERNITY
+from openfisca_core.indexed_enums import Enum
+from openfisca_nsw_base.entities import Building
+
+
+
+class BESS2_V5Nov24_demand_response_contract(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Have you signed a demand response contract for your residential solar battery?',
+        'sorting' : 1,
+        'eligibility_clause' : """A replacement solar battery is not eligible under PDRS Activity BESS2. In PDRS BESS2 the activity definition states that the activity must be sign a behind the meter residential battery energy storage system up to a demand response contract."""
+    }
+
+
+class BESS2_V5Nov24_existing_solar_battery(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Is there an existing solar battery already installed at this address?',
+        'sorting' : 2,
+        'eligibility_clause' : """In PDRS BESS2 Eligibility Requirements Clause 1 it states that there must be an existing battery energy storage system installed at the National Metering Identifier."""
+    }
+
+
+class BESS2_V5Nov24_solar_panels_existing_address(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Are there solar panels already installed at the existing address?',
+        'sorting' : 3,
+        'eligibility_clause' : """In PDRS BESS2 Eligibility Requirements Clause 2 it states that a behind the meter solar photovoltaic system must be installed at the same National Metering Identifier as the existing battery energy storage system."""
+    }
+    
+
+class BESS2_V5Nov24_life_support_equipment(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Are you aware that demand response is not allowed where there is life support equipment?',
+        'sorting' : 4,
+        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 3 it states that there must not be any Life Support Equipment used at the Site."""
+    }
+
+
+class BESS2_V5Nov24_battery_capacity(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Is the battery capacity between 2- 28kWh?',
+        'sorting' : 5,
+        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 2 it states that the End-User Equipment must have a usable battery capacity greater than 2 kWh and less than 28 kWh as recorded on the approved product list specified by the Scheme Administrator."""
+    }
+
+
+class BESS2_V5Nov24_implementation_date(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Was the battery installed within the last seven years?',
+        'sorting' : 6,
+        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements clause 3 it states that the End-User Equipment must have an installation date within 7 years of the Implementation Date as listed on the DER Register."""        
+    }
+
+
+class BESS2_V5Nov24_internet_connectable(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Is the battery internet connectable?',
+        'sorting' : 7,
+        'eligibility_clause' : """In PDRS BESS2 Implementation Requirements clause 1 it states that the internet connection and Demand Response Aggregator control of the End-User Equipment must be demonstrated to be operational to the satisfaction of the Scheme Administrator."""
+    }
+
+
+class BESS2_V5Nov24_battery_controllable_third_party(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Is the battery controllable by a third party energy retailer or service provider?',
+        'sorting' : 8,
+        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 3 it states that the End-User Equipment must be internet connectable and controllable by a Demand Response Aggregator."""
+    }
+
+
+class BESS2_V5Nov24_approved_battery_list(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Is the battery a registered product on the Clean Energy Council approved battery list?',
+        'sorting' : 9,
+        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements clause 1 it states that the End-User Equipment must be listed on the approved product list specified by the Scheme Administrator."""
+    }

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_activity_eligibility_parameters.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_activity_eligibility_parameters.py
@@ -12,9 +12,9 @@ class BESS2_V5Nov24_demand_response_contract(Variable):
     default_value = True
     definition_period = ETERNITY
     metadata = {
-        'display_question' : 'Have you signed a demand response contract for your residential solar battery?',
+        'display_question' : 'Are you aware that you need to sign a demand response contract for your solar battery?',
         'sorting' : 1,
-        'eligibility_clause' : """A replacement solar battery is not eligible under PDRS Activity BESS2. In PDRS BESS2 the activity definition states that the activity must be sign a behind the meter residential battery energy storage system up to a demand response contract."""
+        'eligibility_clause' : """The PDRS BESS2 activity is to sign a behind the meter Battery Energy Storage System up to a demand response contract."""
     }
 
 
@@ -24,9 +24,9 @@ class BESS2_V5Nov24_existing_solar_battery(Variable):
     default_value = True
     definition_period = ETERNITY
     metadata = {
-        'display_question' : 'Is there an existing solar battery already installed at this address?',
+        'display_question' : 'Is there a solar battery already installed at this address?',
         'sorting' : 2,
-        'eligibility_clause' : """In PDRS BESS2 Eligibility Requirements Clause 1 it states that there must be an existing battery energy storage system installed at the National Metering Identifier."""
+        'eligibility_clause' : """In PDRS BESS2 Eligibility Requirements Clause 1 it states that there must be an existing Battery Energy Storage System installed at the National Metering Identifier(s)."""
     }
 
 
@@ -36,9 +36,9 @@ class BESS2_V5Nov24_solar_panels_existing_address(Variable):
     default_value = True
     definition_period = ETERNITY
     metadata = {
-        'display_question' : 'Are there solar panels already installed at the existing address?',
+        'display_question' : 'Are there solar panels already installed at this address?',
         'sorting' : 3,
-        'eligibility_clause' : """In PDRS BESS2 Eligibility Requirements Clause 2 it states that a behind the meter solar photovoltaic system must be installed at the same National Metering Identifier as the existing battery energy storage system."""
+        'eligibility_clause' : """In PDRS BESS2 Eligibility Requirements Clause 2 it states that a behind the meter solar photovoltaic system must be installed at the same National Metering Identifier(s) as the existing Battery Energy Storage System."""
     }
     
 
@@ -54,6 +54,19 @@ class BESS2_V5Nov24_life_support_equipment(Variable):
     }
 
 
+class BESS2_V5Nov24_engaged_ACP(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Will an Accredited Certificate Provider be engaged before the implementation date?',
+        'sorting' : 5,
+        'eligibility_clause' : """In PDRS Clause 6 it states that an Accredited Certificate Provider may only create Peak Reduction Certificates for a Recognised Peak Activity if:<br />
+                                  (a) the Accredited Certificate Provider is accredited in respect of the activity on or before the Implementation Date for the activity."""
+    }
+
+
 class BESS2_V5Nov24_battery_capacity(Variable):
     value_type = bool
     entity = Building
@@ -61,20 +74,44 @@ class BESS2_V5Nov24_battery_capacity(Variable):
     definition_period = ETERNITY
     metadata = {
         'display_question' : 'Is the battery capacity between 2- 28kWh?',
-        'sorting' : 5,
-        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 2 it states that the End-User Equipment must have a usable battery capacity greater than 2 kWh and less than 28 kWh as recorded on the approved product list specified by the Scheme Administrator."""
+        'sorting' : 6,
+        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 2 it states that the End-User Equipment must have a Usable Battery Capacity greater than 2 kWh and less than 28 kWh as recorded on the approved product list specified by the Scheme Administrator."""
     }
 
 
-class BESS2_V5Nov24_implementation_date(Variable):
+class BESS2_V5Nov24_length_battery_warranty(Variable):
     value_type = bool
     entity = Building
     default_value = True
     definition_period = ETERNITY
     metadata = {
-        'display_question' : 'Was the battery installed within the last seven years?',
-        'sorting' : 6,
-        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements clause 3 it states that the End-User Equipment must have an installation date within 7 years of the Implementation Date as listed on the DER Register."""        
+        'display_question' : 'Is there at least 6 years remaining on the battery warranty?',
+        'sorting' : 7,
+        'eligibility_clause' : """In PDRS BESS1 Equipment Requirements Clause 3 it states that each item of End-User Equipment must have a minimum 6 years remaining on the warranty."""
+    }
+
+
+class BESS2_V5Nov24_temperature_range_warranty(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Does the warranty define the normal use conditions of the battery as a minimum ambient temperature range of -10°C to 50°C?',
+        'sorting' : 8,
+        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 4 it states that each End-User Equipment warranty must define the normal use conditions during the operation of the End-User Equipment as not being less than a minimum ambient temperature range of -10°C to 50°C."""
+    }
+
+
+class BESS2_V5Nov24_minimum_throughput_warranty_before_April_2026(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Does the warranty include a minimum throughput of 2.8MWh per kWh of usable capacity?',
+        'sorting' : 9,
+        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 4 it states that each End-User Equipment warranty must define the normal use conditions during the operation of the End-User Equipment as not being less than a minimum warranted cumulative energy throughput equivalent to 2.8 MWh per kWh of Usable Battery Capacity where the Implementation Date is before 1 April 2026."""
     }
 
 
@@ -85,8 +122,8 @@ class BESS2_V5Nov24_internet_connectable(Variable):
     definition_period = ETERNITY
     metadata = {
         'display_question' : 'Is the battery internet connectable?',
-        'sorting' : 7,
-        'eligibility_clause' : """In PDRS BESS2 Implementation Requirements clause 1 it states that the internet connection and Demand Response Aggregator control of the End-User Equipment must be demonstrated to be operational to the satisfaction of the Scheme Administrator."""
+        'sorting' : 10,
+        'eligibility_clause' : """In PDRS BESS2 Implementation Requirements Clause 1 it states that the internet connection and Demand Response Aggregator control of the End-User Equipment must be demonstrated to be operational to the satisfaction of the Scheme Administrator."""
     }
 
 
@@ -97,8 +134,8 @@ class BESS2_V5Nov24_battery_controllable_third_party(Variable):
     definition_period = ETERNITY
     metadata = {
         'display_question' : 'Is the battery controllable by a third party energy retailer or service provider?',
-        'sorting' : 8,
-        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 3 it states that the End-User Equipment must be internet connectable and controllable by a Demand Response Aggregator."""
+        'sorting' : 11,
+        'eligibility_clause' : """In PDRS BESS2 Implementation Requirements Clause 1 it states that the internet connection and Demand Response Aggregator control of the End-User Equipment must be demonstrated to be operational to the satisfaction of the Scheme Administrator."""
     }
 
 
@@ -109,6 +146,6 @@ class BESS2_V5Nov24_approved_battery_list(Variable):
     definition_period = ETERNITY
     metadata = {
         'display_question' : 'Is the battery a registered product on the Clean Energy Council approved battery list?',
-        'sorting' : 9,
-        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements clause 1 it states that the End-User Equipment must be listed on the approved product list specified by the Scheme Administrator."""
+        'sorting' : 12,
+        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 1 it states that the End-User Equipment must be listed on the approved product list specified by the Scheme Administrator."""
     }

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_eligibility.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_eligibility.py
@@ -23,15 +23,17 @@ class BESS2_V5Nov24_installation_final_activity_eligibility(Variable):
         existing_solar_battery = buildings('BESS2_V5Nov24_existing_solar_battery', period)
         solar_panels_existing_address = buildings('BESS2_V5Nov24_solar_panels_existing_address', period)
         life_support_equipment = buildings('BESS2_V5Nov24_life_support_equipment', period)
+        ACP_engaged = buildings('BESS2_V5Nov24_engaged_ACP', period)
         battery_capacity = buildings('BESS2_V5Nov24_battery_capacity', period)
-        implementation_date = buildings('BESS2_V5Nov24_implementation_date', period)
+        battery_warranty_length = buildings('BESS2_V5Nov24_length_battery_warranty', period)
+        battery_warranty_temperature_range = buildings('BESS2_V5Nov24_temperature_range_warranty', period)
+        battery_warranty_throughput_before_April_2026 = buildings ('BESS2_V5Nov24_minimum_throughput_warranty_before_April_2026', period)
         battery_internet_connectable = buildings('BESS2_V5Nov24_internet_connectable', period)
         battery_controllable_third_party = buildings('BESS2_V5Nov24_battery_controllable_third_party', period)
         approved_battery_list = buildings('BESS2_V5Nov24_approved_battery_list', period)
 
-
-
         end_formula = (demand_response_contract * existing_solar_battery * solar_panels_existing_address * life_support_equipment *
-                       battery_capacity * implementation_date * battery_internet_connectable * battery_controllable_third_party * approved_battery_list)
+                       ACP_engaged * battery_capacity * battery_warranty_length * battery_warranty_temperature_range * 
+                       battery_warranty_throughput_before_April_2026 * battery_internet_connectable * battery_controllable_third_party * approved_battery_list)
 
         return end_formula

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_eligibility.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_eligibility.py
@@ -1,0 +1,37 @@
+from distutils.command.build import build
+from openfisca_core.variables import Variable
+from openfisca_core.periods import ETERNITY
+from openfisca_core.indexed_enums import Enum
+from openfisca_nsw_base.entities import Building
+import numpy as np
+
+
+class BESS2_V5Nov24_installation_final_activity_eligibility(Variable):
+    """
+        Formula to calculate the BESS1 installation activity eligibility
+    """
+    value_type = bool
+    entity = Building
+    definition_period = ETERNITY
+    metadata = {
+        "alias": "BESS2 activity installation eligibility requirements",
+        "variable-type": "output"
+    }
+
+    def formula(buildings, period, parameter):
+        demand_response_contract = buildings('BESS2_V5Nov24_demand_response_contract', period)
+        existing_solar_battery = buildings('BESS2_V5Nov24_existing_solar_battery', period)
+        solar_panels_existing_address = buildings('BESS2_V5Nov24_solar_panels_existing_address', period)
+        life_support_equipment = buildings('BESS2_V5Nov24_life_support_equipment', period)
+        battery_capacity = buildings('BESS2_V5Nov24_battery_capacity', period)
+        implementation_date = buildings('BESS2_V5Nov24_implementation_date', period)
+        battery_internet_connectable = buildings('BESS2_V5Nov24_internet_connectable', period)
+        battery_controllable_third_party = buildings('BESS2_V5Nov24_battery_controllable_third_party', period)
+        approved_battery_list = buildings('BESS2_V5Nov24_approved_battery_list', period)
+
+
+
+        end_formula = (demand_response_contract * existing_solar_battery * solar_panels_existing_address * life_support_equipment *
+                       battery_capacity * implementation_date * battery_internet_connectable * battery_controllable_third_party * approved_battery_list)
+
+        return end_formula

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/certificate_estimation/BESS2_V5Nov24_PRC_calculation.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/certificate_estimation/BESS2_V5Nov24_PRC_calculation.py
@@ -1,0 +1,136 @@
+from openfisca_core.variables import Variable
+from openfisca_core.periods import ETERNITY
+from openfisca_core.indexed_enums import Enum
+from openfisca_nsw_base.entities import Building
+
+import numpy as np
+
+
+class BESS2_V5Nov24_demand_response_component(Variable):
+    value_type = float
+    entity = Building
+    definition_period = ETERNITY
+    label = 'Demand response component kW'
+    metadata = {
+        'variable-type': 'output'
+    }
+
+    def formula(buildings, period, parameters):
+        usable_battery_capacity = buildings('BESS2_V5Nov24_usable_battery_capacity', period)
+        demand_reduction_factor = 0.0647
+
+        demand_response_component = usable_battery_capacity * demand_reduction_factor
+        return demand_response_component
+
+
+class BESS2_V5Nov24_peak_demand_response_capacity(Variable):
+    value_type = float
+    entity = Building
+    definition_period = ETERNITY
+    label = 'Peak demand response capacity kW'
+    metadata = {
+        'variable-type': 'output'
+    }
+
+    def formula(buildings, period, parameters):
+        demand_response_component = buildings('BESS2_V5Nov24_demand_response_component', period)
+        firmness_factor = parameters(period).PDRS.table_A6_firmness_factor['firmness_factor']['BESS2']
+
+        peak_demand_response_capacity = demand_response_component * firmness_factor
+        return peak_demand_response_capacity
+
+
+class BESS2_V5Nov24_peak_demand_annual_savings(Variable):
+    value_type = float
+    entity = Building
+    definition_period = ETERNITY
+    label = 'Peak demand annual savings'
+    metadata = {
+        "variable-type": "output"
+    }
+
+    def formula(buildings, period, parameters):
+        #usable battery capacity
+        usable_battery_capacity = buildings('BESS2_V5Nov24_usable_battery_capacity', period)
+
+        #demand response component
+        demand_reduction_factor = 0.0647
+
+        demand_response_component = usable_battery_capacity * demand_reduction_factor
+
+        #peak demand response capacity
+        firmness_factor = parameters(period).PDRS.table_A6_firmness_factor['firmness_factor']['BESS2']
+
+        peak_demand_response_capacity = demand_response_component * firmness_factor
+
+        #peak demand annual savings
+        summer_peak_demand_duration = 6
+
+        #lifetime
+        lifetime = 3
+
+        peak_demand_annual_savings = peak_demand_response_capacity * summer_peak_demand_duration * lifetime
+
+        peak_demand_annual_savings_return = np.select([
+                peak_demand_annual_savings <= 0, peak_demand_annual_savings > 0
+            ],
+            [
+                0, peak_demand_annual_savings
+            ])
+        
+        
+        return peak_demand_annual_savings_return
+
+
+class BESS2_V5Nov24_peak_demand_reduction_capacity(Variable):
+    value_type = float
+    entity = Building
+    definition_period = ETERNITY
+    label = 'Peak demand reduction capacity kW'
+    metadata = {
+        'variable-type': 'output'
+    }
+
+    def formula(buildings, period, parameters):
+       peak_demand_response_capacity = buildings('BESS2_V5Nov24_peak_demand_response_capacity', period)
+       summer_peak_demand_reduction_duration = 6
+       lifetime = 3
+       
+       peak_demand_reduction_capacity = peak_demand_response_capacity * summer_peak_demand_reduction_duration * lifetime
+       return peak_demand_reduction_capacity
+
+
+class BESS2_V5Nov24_PRC_calculation(Variable):
+    value_type = float
+    entity = Building
+    definition_period = ETERNITY
+    label = 'BESS2 PRC calculation'
+    metadata = {
+        'variable-type': 'output'
+    }
+
+    def formula(buildings, period, parameters):
+        peak_demand_reduction_capacity = buildings('BESS2_V5Nov24_peak_demand_reduction_capacity', period)
+        network_loss_factor = buildings('BESS2_V5Nov24_get_network_loss_factor_by_postcode', period)
+        installation_eligibility = buildings('BESS2_V5Nov24_installation_activity', period)
+
+        BESS2_eligible_PRCs = np.select(
+        [
+            installation_eligibility,
+            np.logical_not(installation_eligibility)
+        ],
+        [
+            (peak_demand_reduction_capacity * network_loss_factor * 10),
+            0
+        ])
+
+        result_to_return = np.select(
+        [
+            BESS2_eligible_PRCs <= 0, 
+            BESS2_eligible_PRCs > 0
+        ],
+        [
+            0, 
+            BESS2_eligible_PRCs
+        ])
+        return result_to_return

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/certificate_estimation/BESS2_V5Nov24_PRC_variables.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/certificate_estimation/BESS2_V5Nov24_PRC_variables.py
@@ -1,0 +1,63 @@
+from openfisca_core.variables import Variable
+from openfisca_core.periods import ETERNITY
+from openfisca_core.indexed_enums import Enum
+from openfisca_nsw_base.entities import Building
+
+import numpy as np
+
+
+""" Parameters for BESS2 PRC Calculation
+    These variables use Rule tables and CEC Approved Battery Registry data
+"""
+
+
+class BESS2_V5Nov24_PDRS__postcode(Variable):
+    value_type = int
+    entity = Building
+    definition_period = ETERNITY
+    metadata= {
+        'variable-type' : 'user-input',
+        'label': 'Postcode',
+        'display_question' : 'Postcode where the installation has taken place',
+        'sorting' : 1        
+    }
+
+
+class BESS2_V5Nov24_installation_activity(Variable):
+    value_type = bool
+    default_value = True
+    entity = Building
+    definition_period = ETERNITY
+    metadata = {
+        'variable-type': 'user-input',
+        'label': 'New installation or replacement activity',
+        'display_question': 'Is the activity a new installation?',
+        'sorting' : 2
+    }
+
+
+class BESS2_V5Nov24_usable_battery_capacity(Variable):
+    value_type = float
+    entity = Building
+    definition_period = ETERNITY
+    metadata={
+        'variable-type' : 'user-input',
+        'label': 'Usable battery capacity (kWh)',
+        'display_question' : 'The actual amount of energy you can use',
+        'sorting' : 3        
+    }
+
+
+class BESS2_V5Nov24_get_network_loss_factor_by_postcode(Variable):
+    value_type = float
+    entity = Building
+    definition_period = ETERNITY
+    metadata = {
+        'variable-type': 'input',
+        'label' : 'Network loss factor is calculated automatically from your postcode. If you have a 0 here, please check your postcode is correct. If the postcode has more than one distribution network service provider, we have chosen the network factor loss with the lowest value.'
+    }
+    def formula(building, period, parameters):
+        postcode = building('BESS2_V5Nov24_PDRS__postcode', period)
+        network_loss_factor = parameters(period).PDRS.table_network_loss_factor_by_postcode
+
+        return network_loss_factor.calc(postcode)


### PR DESCRIPTION
# [DG22-1643]

## Summary
This pull request addresses the following functionality/fixes:
* Updates BESS2 eligibility for the V5 deployment
* Added some full stops onto BESS1 clauses that were missing them

## Technical changes
This is a summary of technical changes to the codebase.

* Created a new BESS2_Nov24 folder for the V5 deployment - this folder includes both eligibility and certificates (certificates has not been touched yet, and is waiting on potential battery registry hook up)
* Updated all variables in this folder to the new naming convention (BESS2_Nov24)
* Added the new BESS2 eligibility variables
* Updated BESS2 eligibility formula
* Tested new BESS2 variables (in particular, that an indoor installation has a smoke alarm)
* Updated the BESS2 eligibility formula test
* All tests are passing in the codebase


## Links and resources
Jira ticket: https://essnsw.atlassian.net/browse/DG22-1643

## Pre deployment tasks
None

## Post deployment tasks
 - [ ] Once the PR has been approved the BESS2 UI needs to be hooked up to the new variables


[DG22-1643]: https://essnsw.atlassian.net/browse/DG22-1643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ