### PR TITLE
[DG22-2368] Updates BCA-postcode for D17-D20

### DIFF
--- a/openfisca_nsw_safeguard/parameters/ESS/ESS_general/table_A26_May25_BCA_climate_zone_by_postcode.yaml
+++ b/openfisca_nsw_safeguard/parameters/ESS/ESS_general/table_A26_May25_BCA_climate_zone_by_postcode.yaml
@@ -7,170 +7,158 @@ brackets:
       2020-01-01:
         value: 0 # undefined postcodes, incl. postcodes below 2000 have a BCA Climate Zone of 5
   - amount:
+      2020-01-01:        
+        value: 6
+    threshold:
+      2020-01-01:        
+        value: 2115
+  - amount:
+      2020-01-01:       
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2119
+  - amount:
+      2020-01-01:        
+        value: 6
+    threshold:
+      2020-01-01:        
+        value: 2125 
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2126
+  - amount:
+      2020-01-01:        
+        value: 6
+    threshold:
+      2020-01-01:        
+        value: 2127
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2129 
+  - amount:
+      2020-01-01:        
+        value: 6
+    threshold:
+      2020-01-01:        
+        value: 2141 # postcode 2141-2143 have a BCA Climate Zone of 6
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2143
+  - amount:
       2020-01-01:
         value: 6
     threshold:
       2020-01-01:
-        value: 2145 # postcode 2145-2148 have a BCA Climate Zone of 6
+        value: 2144 # postcode 2144 has a BCA Climate Zone of 6, etc
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2149
+  - amount:
+      2020-01-01:        
+        value: 6
+    threshold:
+      2020-01-01:        
+        value: 2150
   - amount:
       2020-01-01:
         value: 5
     threshold:
       2020-01-01:
-        value: 2149 # postcode 2149 has a BCA Climate Zone of 5, etc
+        value: 2159
   - amount:
       2020-01-01:
         value: 6
-    threshold:
-      2020-01-01:
-        value: 2155
-  - amount:
-      2020-01-01:
-        value: 5
     threshold:
       2020-01-01:
         value: 2160
   - amount:
-      2020-01-01:
-        value: 6
-    threshold:
-      2020-01-01:
-        value: 2164
-  - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 5
     threshold:
-      2020-01-01:
-        value: 2169
+      2020-01-01:        
+        value: 2162
   - amount:
       2020-01-01:
         value: 6
     threshold:
       2020-01-01:
-        value: 2170
+        value: 2163
   - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 5
     threshold:
-      2020-01-01:
-        value: 2180
+      2020-01-01:        
+        value: 2181
   - amount:
-      2020-01-01:
-        value: 2
-    threshold:
-      2020-01-01:
-        value: 2312
-  - amount:
-      2020-01-01:
-        value: 5
-    threshold:
-      2020-01-01:
-        value: 2313
-  - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 6
     threshold:
-      2020-01-01:
-        value: 2320
-  - amount:
-      2020-01-01:
-        value: 5
-    threshold:
-      2020-01-01:
-        value: 2321
-  - amount:
-      2020-01-01:
-        value: 6
-    threshold:
-      2020-01-01:
-        value: 2322
-  - amount:
-      2020-01-01:
-        value: 5
-    threshold:
-      2020-01-01:
-        value: 2323
-  - amount:
-      2020-01-01:
-        value: 2
-    threshold:
-      2020-01-01:
-        value: 2324
-  - amount:
-      2020-01-01:
-        value: 6
-    threshold:
-      2020-01-01:
-        value: 2325
-  - amount:
-      2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
+      2020-01-01:        
         value: 2328
   - amount:
       2020-01-01:
-        value: 6
-    threshold:
-      2020-01-01:
-        value: 2330
-  - amount:
-      2020-01-01:
         value: 5
-    threshold:
-      2020-01-01:
-        value: 2332
-  - amount:
-      2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2333
-  - amount:
-      2020-01-01:
-        value: 6
     threshold:
       2020-01-01:
         value: 2334
   - amount:
       2020-01-01:
-        value: 7
+        value: 6
     threshold:
       2020-01-01:
         value: 2336
   - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 4
     threshold:
-      2020-01-01:
-        value: 2342
+      2020-01-01:        
+        value: 2339
   - amount:
-      2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2343
-  - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 5
     threshold:
-      2020-01-01:
+      2020-01-01:        
         value: 2348
   - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 7
     threshold:
-      2020-01-01:
+      2020-01-01:        
         value: 2350
   - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 4
     threshold:
-      2020-01-01:
-        value: 2356
+      2020-01-01:        
+        value: 2352
+  - amount:
+      2020-01-01:        
+        value: 6
+    threshold:
+      2020-01-01:        
+        value: 2354
+  - amount:
+      2020-01-01:        
+        value: 4
+    threshold:
+      2020-01-01:        
+        value: 2355
   - amount:
       2020-01-01:
-        value: 7
+        value: 6
     threshold:
       2020-01-01:
         value: 2358
@@ -179,43 +167,37 @@ brackets:
         value: 4
     threshold:
       2020-01-01:
-        value: 2359
-  - amount:
-      2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
         value: 2360
   - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 5
     threshold:
-      2020-01-01:
+      2020-01-01:        
         value: 2362
   - amount:
       2020-01-01:
-        value: 7
+        value: 8
     threshold:
       2020-01-01:
         value: 2365
   - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 5
     threshold:
-      2020-01-01:
+      2020-01-01:        
         value: 2366
   - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 7
     threshold:
-      2020-01-01:
-        value: 2369
+      2020-01-01:        
+        value: 2368
   - amount:
       2020-01-01:
-        value: 4
+        value: 6
     threshold:
       2020-01-01:
-        value: 2372
+        value: 2370
   - amount:
       2020-01-01:
         value: 5
@@ -239,7 +221,7 @@ brackets:
         value: 5
     threshold:
       2020-01-01:
-        value: 2383
+        value: 2384
   - amount:
       2020-01-01:
         value: 4
@@ -272,24 +254,6 @@ brackets:
         value: 2395
   - amount:
       2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2403
-  - amount:
-      2020-01-01:
-        value: 3
-    threshold:
-      2020-01-01:
-        value: 2405
-  - amount:
-      2020-01-01:
-        value: 4
-    threshold:
-      2020-01-01:
-        value: 2406
-  - amount:
-      2020-01-01:
         value: 5
     threshold:
       2020-01-01:
@@ -307,44 +271,20 @@ brackets:
       2020-01-01:
         value: 2412
   - amount:
-      2020-01-01:
-        value: 6
+      2020-01-01:        
+        value: 4
     threshold:
-      2020-01-01:
-        value: 2415
+      2020-01-01:        
+        value: 2413
   - amount:
       2020-01-01:
         value: 5
     threshold:
       2020-01-01:
-        value: 2416
-  - amount:
-      2020-01-01:
-        value: 6
-    threshold:
-      2020-01-01:
-        value: 2420
+        value: 2414
   - amount:
       2020-01-01:
         value: 2
-    threshold:
-      2020-01-01:
-        value: 2423
-  - amount:
-      2020-01-01:
-        value: 6
-    threshold:
-      2020-01-01:
-        value: 2424
-  - amount:
-      2020-01-01:
-        value: 5
-    threshold:
-      2020-01-01:
-        value: 2426
-  - amount:
-      2020-01-01:
-        value: 5
     threshold:
       2020-01-01:
         value: 2431
@@ -365,7 +305,7 @@ brackets:
         value: 5
     threshold:
       2020-01-01:
-        value: 2442
+        value: 2441
   - amount:
       2020-01-01:
         value: 2
@@ -386,12 +326,6 @@ brackets:
         value: 2452
   - amount:
       2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2453
-  - amount:
-      2020-01-01:
         value: 2
     threshold:
       2020-01-01:
@@ -401,13 +335,13 @@ brackets:
         value: 5
     threshold:
       2020-01-01:
-        value: 2457
+        value: 2458
   - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 2
     threshold:
-      2020-01-01:
-        value: 2460
+      2020-01-01:        
+        value: 2459
   - amount:
       2020-01-01:
         value: 5
@@ -434,16 +368,16 @@ brackets:
         value: 2469
   - amount:
       2020-01-01:
-        value: 7
+        value: 6
     threshold:
       2020-01-01:
-        value: 2476
+        value: 2475
   - amount:
       2020-01-01:
         value: 2
     threshold:
       2020-01-01:
-        value: 2477
+        value: 2476
   - amount:
       2020-01-01:
         value: 5
@@ -455,31 +389,7 @@ brackets:
         value: 6
     threshold:
       2020-01-01:
-        value: 2527
-  - amount:
-      2020-01-01:
-        value: 5
-    threshold:
-      2020-01-01:
-        value: 2528
-  - amount:
-      2020-01-01:
-        value: 6
-    threshold:
-      2020-01-01:
-        value: 2529
-  - amount:
-      2020-01-01:
-        value: 5
-    threshold:
-      2020-01-01:
-        value: 2530
-  - amount:
-      2020-01-01:
-        value: 6
-    threshold:
-      2020-01-01:
-        value: 2533
+        value: 2535
   - amount:
       2020-01-01:
         value: 5
@@ -533,37 +443,31 @@ brackets:
         value: 7
     threshold:
       2020-01-01:
-        value: 2575
+        value: 2580
+  - amount:
+      2020-01-01:        
+        value: 6
+    threshold:
+      2020-01-01:        
+        value: 2582
+  - amount:
+      2020-01-01:        
+        value: 7
+    threshold:
+      2020-01-01:        
+        value: 2583
   - amount:
       2020-01-01:
         value: 6
     threshold:
       2020-01-01:
-        value: 2576
-  - amount:
-      2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2577
-  - amount:
-      2020-01-01:
-        value: 4
-    threshold:
-      2020-01-01:
         value: 2584
   - amount:
-      2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2587
-  - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 4
     threshold:
-      2020-01-01:
-        value: 2588
+      2020-01-01:        
+        value: 2585
   - amount:
       2020-01-01:
         value: 5
@@ -584,7 +488,7 @@ brackets:
         value: 2591
   - amount:
       2020-01-01:
-        value: 7
+        value: 4
     threshold:
       2020-01-01:
         value: 2594
@@ -595,23 +499,83 @@ brackets:
       2020-01-01:
         value: 2595
   - amount:
+      2020-01-01:        
+        value: 4
+    threshold:
+      2020-01-01:        
+        value: 2597
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2598
+  - amount:
       2020-01-01:
         value: 7
     threshold:
       2020-01-01:
+        value: 2600
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2608
+  - amount:
+      2020-01-01:        
+        value: 7
+    threshold:
+      2020-01-01:        
+        value: 2609
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2610
+  - amount:
+      2020-01-01:        
+        value: 7
+    threshold:
+      2020-01-01:        
         value: 2611
   - amount:
       2020-01-01:
         value: 5
     threshold:
       2020-01-01:
-        value: 2612
+        value: 2613
   - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 7
     threshold:
+      2020-01-01:        
+        value: 2614
+  - amount:
       2020-01-01:
-        value: 2618
+        value: 5
+    threshold:
+      2020-01-01:
+        value: 2616
+  - amount:
+      2020-01-01:        
+        value: 7
+    threshold:
+      2020-01-01:        
+        value: 2617
+  - amount:
+      2020-01-01:        
+        value: 6
+    threshold:
+      2020-01-01:        
+        value: 2620
+  - amount:
+      2020-01-01:        
+        value: 7
+    threshold:
+      2020-01-01:        
+        value: 2621
   - amount:
       2020-01-01:
         value: 8
@@ -625,41 +589,29 @@ brackets:
       2020-01-01:
         value: 2626
   - amount:
-      2020-01-01:
-        value: 8
-    threshold:
-      2020-01-01:
-        value: 2627
-  - amount:
-      2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2628
-  - amount:
-      2020-01-01:
-        value: 8
-    threshold:
-      2020-01-01:
-        value: 2629
-  - amount:
-      2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2630
-  - amount:
-      2020-01-01:
+      2020-01-01:        
         value: 5
     threshold:
-      2020-01-01:
-        value: 2634
+      2020-01-01:        
+        value: 2635
   - amount:
       2020-01-01:
         value: 4
     threshold:
       2020-01-01:
         value: 2640
+  - amount:
+      2020-01-01:        
+        value: 7
+    threshold:
+      2020-01-01:        
+        value: 2642
+  - amount:
+      2020-01-01:        
+        value: 4
+    threshold:
+      2020-01-01:        
+        value: 2643
   - amount:
       2020-01-01:
         value: 7
@@ -678,12 +630,6 @@ brackets:
     threshold:
       2020-01-01:
         value: 2653
-  - amount:
-      2020-01-01:
-        value: 5
-    threshold:
-      2020-01-01:
-        value: 2654
   - amount:
       2020-01-01:
         value: 4
@@ -812,7 +758,7 @@ brackets:
         value: 2705
   - amount:
       2020-01-01:
-        value: 4
+        value: 5
     threshold:
       2020-01-01:
         value: 2708
@@ -860,16 +806,10 @@ brackets:
         value: 2728
   - amount:
       2020-01-01:
-        value: 4
-    threshold:
-      2020-01-01:
-        value: 2729
-  - amount:
-      2020-01-01:
         value: 7
     threshold:
       2020-01-01:
-        value: 2730
+        value: 2729
   - amount:
       2020-01-01:
         value: 4
@@ -900,18 +840,6 @@ brackets:
     threshold:
       2020-01-01:
         value: 2747
-  - amount:
-      2020-01-01:
-        value: 5
-    threshold:
-      2020-01-01:
-        value: 2751
-  - amount:
-      2020-01-01:
-        value: 6
-    threshold:
-      2020-01-01:
-        value: 2752
   - amount:
       2020-01-01:
         value: 5
@@ -950,40 +878,28 @@ brackets:
         value: 2773
   - amount:
       2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2776
-  - amount:
-      2020-01-01:
-        value: 6
-    threshold:
-      2020-01-01:
-        value: 2777
-  - amount:
-      2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2778
-  - amount:
-      2020-01-01:
         value: 5
     threshold:
       2020-01-01:
         value: 2781
   - amount:
-      2020-01-01:
-        value: 7
+      2020-01-01:     
+        value: 6
     threshold:
-      2020-01-01:
+      2020-01-01:        
         value: 2782
   - amount:
-      2020-01-01:
+      2020-01-01:        
+        value: 7
+    threshold:
+      2020-01-01:        
+        value: 2787
+  - amount:
+      2020-01-01:        
         value: 5
     threshold:
-      2020-01-01:
-        value: 2788
+      2020-01-01:        
+        value: 2788     
   - amount:
       2020-01-01:
         value: 7
@@ -995,7 +911,7 @@ brackets:
         value: 4
     threshold:
       2020-01-01:
-        value: 2794
+        value: 2793
   - amount:
       2020-01-01:
         value: 7
@@ -1022,34 +938,40 @@ brackets:
         value: 2801
   - amount:
       2020-01-01:
-        value: 7
+        value: 4
     threshold:
       2020-01-01:
         value: 2803
-  - amount:
-      2020-01-01:
-        value: 4
-    threshold:
-      2020-01-01:
-        value: 2804
-  - amount:
-      2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2807
-  - amount:
-      2020-01-01:
-        value: 4
-    threshold:
-      2020-01-01:
-        value: 2808
   - amount:
       2020-01-01:
         value: 5
     threshold:
       2020-01-01:
         value: 2811
+  - amount:
+      2020-01-01:        
+        value: 4
+    threshold:
+      2020-01-01:
+        value: 2812
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2813
+  - amount:
+      2020-01-01:        
+        value: 4
+    threshold:
+      2020-01-01:        
+        value: 2815
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2816
   - amount:
       2020-01-01:
         value: 4
@@ -1099,6 +1021,12 @@ brackets:
       2020-01-01:
         value: 2845
   - amount:
+      2020-01-01:        
+        value: 6
+    threshold:
+      2020-01-01:        
+        value: 2848
+  - amount:
       2020-01-01:
         value: 5
     threshold:
@@ -1106,7 +1034,7 @@ brackets:
         value: 2851
   - amount:
       2020-01-01:
-        value: 4
+        value: 6
     threshold:
       2020-01-01:
         value: 2852
@@ -1124,27 +1052,15 @@ brackets:
         value: 2864
   - amount:
       2020-01-01:
-        value: 7
-    threshold:
-      2020-01-01:
-        value: 2865
-  - amount:
-      2020-01-01:
-        value: 4
-    threshold:
-      2020-01-01:
-        value: 2868
-  - amount:
-      2020-01-01:
         value: 5
     threshold:
       2020-01-01:
         value: 2872
   - amount:
-      2020-01-01:
-        value: 6
+      2020-01-01:        
+        value: 4
     threshold:
-      2020-01-01:
+      2020-01-01:        
         value: 2873
   - amount:
       2020-01-01:
@@ -1172,10 +1088,40 @@ brackets:
         value: 2898
   - amount:
       2020-01-01:
-        value: 5
+        value: 7
     threshold:
       2020-01-01:
         value: 2900
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2901
+  - amount:
+      2020-01-01:        
+        value: 7
+    threshold:
+      2020-01-01:        
+        value: 2902
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2907
+  - amount:
+      2020-01-01:        
+        value: 7
+    threshold:
+      2020-01-01:        
+        value: 2911
+  - amount:
+      2020-01-01:        
+        value: 5
+    threshold:
+      2020-01-01:        
+        value: 2915
   - amount:
       2020-01-01:
         value: 4

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D17_ESSJun24/D17_ESSJun24_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D17_ESSJun24/D17_ESSJun24_ESC_calculation.yaml
@@ -6,14 +6,16 @@
       [
         2354,
         2365,
-        2074
+        2074,
+        2793
       ]
   output:
     D17_ESSJun24_BCA_climate_zone_by_postcode_int:
       [
-       7,
-       7,
-       5
+        6,
+        8,
+        5,
+        4
       ]
 
 - name: test postcode to BCA climate zone to heat pump zone
@@ -22,9 +24,9 @@
   input:
     D17_ESSJun24_PDRS__postcode:
       [
-        2324, #BCA climate zone 2 - HP zone 3
+        2324, #BCA climate zone 5 - HP zone 3
         2588, #BCA climate zone 4 - HP zone 3
-        2328, #BCA climate zone 7 - HP zone 5
+        2328, #BCA climate zone 6 - HP zone 3
         2624  #BCA climate zone 8 - HP zone 5
       ]
   output:
@@ -32,7 +34,7 @@
       [
         3,
         3,
-        5,
+        3,
         5
       ]
 
@@ -358,4 +360,22 @@
         46.76,
         92,
         0 #Bs and Be not valid
+      ]
+
+- name: test BCA climate zone by postcode corrected
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    D17_ESSJun24_PDRS__postcode:
+      [
+        2793,
+        2786,
+        2873
+      ]
+  output:
+    D17_ESSJun24_BCA_climate_zone_by_postcode_int:
+      [
+        4,
+        6,
+        4
       ]

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D18_ESSJun24/D18_ESSJun24_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D18_ESSJun24/D18_ESSJun24_ESC_calculation.yaml
@@ -11,8 +11,8 @@
   output:
     D18_ESSJun24_BCA_climate_zone_by_postcode_int:
       [
-        7,
-        7,
+        6,
+        8,
         5
       ]
 
@@ -22,9 +22,9 @@
   input:
     D18_ESSJun24_PDRS__postcode:
       [
-        2324, #BCA climate zone 2 - HP zone 3
+        2324, #BCA climate zone 5 - HP zone 3
         2588, #BCA climate zone 4 - HP zone 3
-        2328, #BCA climate zone 7 - HP zone 5
+        2328, #BCA climate zone 6 - HP zone 5
         2624  #BCA climate zone 8 - HP zone 5
       ]
   output:
@@ -32,7 +32,7 @@
       [
         3,
         3,
-        5,
+        3,
         5
       ]
 
@@ -270,4 +270,22 @@
         41.52,
         81.52,
         0 #Bs and Be not valid
+      ]
+
+- name: test BCA climate zone by postcode corrected
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    D18_ESSJun24_PDRS__postcode:
+      [
+        2793,
+        2786,
+        2873
+      ]
+  output:
+    D18_ESSJun24_BCA_climate_zone_by_postcode_int:
+      [
+        4,
+        6,
+        4
       ]

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D19_ESSJun24/D19_ESSJun24_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D19_ESSJun24/D19_ESSJun24_ESC_calculation.yaml
@@ -11,8 +11,8 @@
   output:
     D19_ESSJun24_BCA_climate_zone_by_postcode_int:
       [
-        7,
-        7,
+        6,
+        8,
         5
       ]
 
@@ -24,7 +24,7 @@
       [
         2324, #BCA climate zone 2 - HP zone 3
         2588, #BCA climate zone 4 - HP zone 3
-        2328, #BCA climate zone 7 - HP zone 5
+        2328, #BCA climate zone 6 - HP zone 3
         2624  #BCA climate zone 8 - HP zone 5
       ]
   output:
@@ -32,7 +32,7 @@
       [
         3,
         3,
-        5,
+        3,
         5
       ]
 
@@ -391,4 +391,22 @@
         112.78,
         13.25,
         8.69
+      ]
+
+- name: test BCA climate zone by postcode corrected
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    D19_ESSJun24_PDRS__postcode:
+      [
+        2115,
+        2123,
+        2128
+      ]
+  output:
+    D19_ESSJun24_BCA_climate_zone_by_postcode_int:
+      [
+        6,
+        5,
+        6
       ]

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D20_ESSJun24/D20_ESSJun24_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D20_ESSJun24/D20_ESSJun24_ESC_calculation.yaml
@@ -11,8 +11,8 @@
   output:
     D20_ESSJun24_BCA_climate_zone_by_postcode_int:
       [
-        7,
-        7,
+        6,
+        8,
         5
       ]
 
@@ -24,7 +24,7 @@
       [
         2324, #BCA climate zone 2 - HP zone 3
         2588, #BCA climate zone 4 - HP zone 3
-        2328, #BCA climate zone 7 - HP zone 5
+        2328, #BCA climate zone 6 - HP zone 5
         2624  #BCA climate zone 8 - HP zone 5
       ]
   output:
@@ -32,7 +32,7 @@
       [
         3,
         3,
-        5,
+        3,
         5
       ]
 
@@ -308,4 +308,23 @@
         22.54,
         33.18,
         0 #Bs and Be are zero and not eligible for savings
+      ]
+
+
+- name: test BCA climate zone by postcode corrected
+  period: 2025
+  absolute_error_margin: 0
+  input:
+    D20_ESSJun24_PDRS__postcode:
+      [
+        2115,
+        2123,
+        2128
+      ]
+  output:
+    D20_ESSJun24_BCA_climate_zone_by_postcode_int:
+      [
+        6,
+        5,
+        6
       ]

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D17_ESSJun24/certificate_estimation/D17_ESSJun24_ESC_variables.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D17_ESSJun24/certificate_estimation/D17_ESSJun24_ESC_variables.py
@@ -34,7 +34,7 @@ class D17_ESSJun24_BCA_climate_zone_by_postcode(Variable):
     def formula(buildings, period, parameters):
         postcode = buildings('D17_ESSJun24_PDRS__postcode', period)
         # Returns an integer
-        climate_zone = parameters(period).ESS.ESS_general.table_A26_BCA_climate_zone_by_postcode       
+        climate_zone = parameters(period).ESS.ESS_general.table_A26_May25_BCA_climate_zone_by_postcode      
         climate_zone_int = climate_zone.calc(postcode)
         BCA_climate_zone_to_check = np.select(
             [
@@ -72,7 +72,7 @@ class D17_ESSJun24_BCA_climate_zone_by_postcode_int(Variable):
     def formula(buildings, period, parameters):
         postcode = buildings('D17_ESSJun24_PDRS__postcode', period)
         # Returns an integer
-        climate_zone = parameters(period).ESS.ESS_general.table_A26_BCA_climate_zone_by_postcode       
+        climate_zone = parameters(period).ESS.ESS_general.table_A26_May25_BCA_climate_zone_by_postcode
         climate_zone_int = climate_zone.calc(postcode)
 
         return climate_zone_int

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D18_ESSJun24/certificate_estimation/D18_ESSJun24_ESC_variables.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D18_ESSJun24/certificate_estimation/D18_ESSJun24_ESC_variables.py
@@ -35,7 +35,7 @@ class D18_ESSJun24_BCA_climate_zone_by_postcode(Variable):
     def formula(buildings, period, parameters):
         postcode = buildings('D18_ESSJun24_PDRS__postcode', period)
         # Returns an integer
-        climate_zone = parameters(period).ESS.ESS_general.table_A26_BCA_climate_zone_by_postcode       
+        climate_zone = parameters(period).ESS.ESS_general.table_A26_May25_BCA_climate_zone_by_postcode       
         climate_zone_int = climate_zone.calc(postcode)
         BCA_climate_zone_to_check = np.select(
             [
@@ -73,7 +73,7 @@ class D18_ESSJun24_BCA_climate_zone_by_postcode_int(Variable):
     def formula(buildings, period, parameters):
         postcode = buildings('D18_ESSJun24_PDRS__postcode', period)
         # Returns an integer
-        climate_zone = parameters(period).ESS.ESS_general.table_A26_BCA_climate_zone_by_postcode       
+        climate_zone = parameters(period).ESS.ESS_general.table_A26_May25_BCA_climate_zone_by_postcode       
         climate_zone_int = climate_zone.calc(postcode)
 
         return climate_zone_int

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D19_ESSJun24/certificate_estimation/D19_ESSJun24_ESC_variables.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D19_ESSJun24/certificate_estimation/D19_ESSJun24_ESC_variables.py
@@ -35,7 +35,7 @@ class D19_ESSJun24_BCA_climate_zone_by_postcode(Variable):
     def formula(buildings, period, parameters):
         postcode = buildings('D19_ESSJun24_PDRS__postcode', period)
         # Returns an integer
-        climate_zone = parameters(period).ESS.ESS_general.table_A26_BCA_climate_zone_by_postcode       
+        climate_zone = parameters(period).ESS.ESS_general.table_A26_May25_BCA_climate_zone_by_postcode       
         climate_zone_int = climate_zone.calc(postcode)
         BCA_climate_zone_to_check = np.select(
             [
@@ -73,7 +73,7 @@ class D19_ESSJun24_BCA_climate_zone_by_postcode_int(Variable):
     def formula(buildings, period, parameters):
         postcode = buildings('D19_ESSJun24_PDRS__postcode', period)
         # Returns an integer
-        climate_zone = parameters(period).ESS.ESS_general.table_A26_BCA_climate_zone_by_postcode       
+        climate_zone = parameters(period).ESS.ESS_general.table_A26_May25_BCA_climate_zone_by_postcode       
         climate_zone_int = climate_zone.calc(postcode)
 
         return climate_zone_int

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D20_ESSjun24/certificate_estimation/D20_ESSJun24_ESC_variables.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D20_ESSjun24/certificate_estimation/D20_ESSJun24_ESC_variables.py
@@ -34,7 +34,7 @@ class D20_ESSJun24_BCA_climate_zone_by_postcode(Variable):
     def formula(buildings, period, parameters):
         postcode = buildings('D20_ESSJun24_PDRS__postcode', period)
         # Returns an integer
-        climate_zone = parameters(period).ESS.ESS_general.table_A26_BCA_climate_zone_by_postcode       
+        climate_zone = parameters(period).ESS.ESS_general.table_A26_May25_BCA_climate_zone_by_postcode       
         climate_zone_int = climate_zone.calc(postcode)
         BCA_climate_zone_to_check = np.select(
             [
@@ -72,7 +72,7 @@ class D20_ESSJun24_BCA_climate_zone_by_postcode_int(Variable):
     def formula(buildings, period, parameters):
         postcode = buildings('D20_ESSJun24_PDRS__postcode', period)
         # Returns an integer
-        climate_zone = parameters(period).ESS.ESS_general.table_A26_BCA_climate_zone_by_postcode       
+        climate_zone = parameters(period).ESS.ESS_general.table_A26_May25_BCA_climate_zone_by_postcode       
         climate_zone_int = climate_zone.calc(postcode)
 
         return climate_zone_int


### PR DESCRIPTION
# [DG22-2368]

## Summary
This pull request addresses the following functionality/fixes:
* Adds a new table for BCA-postcode conversion
* Hooks up new table to D17-D20 and all tests

## Technical changes
This is a summary of technical changes to the codebase.
* Adds new table with updated BCA-postcode conversions 
* Connects D17-D20 to the new BCA-postcode table_A26_May25_BCA_climate_zone_by_postcode

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2368

## Pre deployment tasks
- [ ] This is only the first group of activities, there are still 5 activities that need to be hooked up to the new table and errors fixed

## Post deployment tasks
- [ ] Test changes on Dev
