### PR TITLE
[DG22-2407] F4 estimator using AEER/ACOP product values when it should be using the TCSPF/HSPF

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/HVAC2_PDRSAug24/HVAC2_PDRSAug24_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/HVAC2_PDRSAug24/HVAC2_PDRSAug24_ESC_calculation.yaml
@@ -267,35 +267,50 @@
         1.9
       ]
 
-- name: test minimum TCSFP AEER 
+- name: test minimum TCSPF AEER
   period: 2022
   absolute_error_margin: 0.1
   input:
     HVAC2_PDRSAug24_Air_Conditioner_type:
       [
-        non_ducted_split_system,
-        non_ducted_split_system
+        non_ducted_split_system, # brand: MITSUBISHI HEAVY INDUSTRIES, model: DXC28ZRA-W - DXK28ZRA-W
+        non_ducted_split_system, # brand: ACTRON AIR, model: CRC-100CS - CRE-100CS
+        non_ducted_split_system, # brand: BRAEMAR, model: ACHV25D1S-ASHV25D1S
+        ducted_split_system, # brand: MAMMOTH, model: MSR-J100
+        ducted_split_system, # brand: AIRO, model: APC20RW
       ]
     HVAC2_PDRSAug24_cooling_capacity_input:
       [
-        8,  #expected AEER 3.5
-        8   #expected TCSPF 4.5
+        8,
+        10.95,
+        2.7,
+        27,
+        2.05,
       ]
     HVAC2_PDRSAug24_TCSPF_mixed:
       [
-        0,  #use AEER
-        20  #use TCSPF instead of AEER, > expected 4.5
+        5.801, # Ignore AEER
+        9.933, # Ignore AEER
+        6.896, # Ignore AEER
+        0, # use AEER
+        0, # use AEER
       ]
     HVAC2_PDRSAug24_rated_AEER_input:
       [
-         0,  #AEER < expected 3.5
-        50  
+        3.5872,
+        4.1893,
+        3.7271,
+        3.8382,
+        2.6115,
       ]
   output:
     HVAC2_PDRSAug24_TCSPF_or_AEER_exceeds_ESS_benchmark:
       [
         false,
-        true
+        true,
+        false,
+        true,
+        false,
       ]
 
 - name: test minimum HSPF ACOP 

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/HVAC2_PDRSAug24/certification_estimation/HVAC2_PDRSAug24_ESC_variables.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/HVAC2_PDRSAug24/certification_estimation/HVAC2_PDRSAug24_ESC_variables.py
@@ -351,8 +351,8 @@ class HVAC2_PDRSAug24_TCSPF_or_AEER_exceeds_ESS_benchmark(Variable):
         TCSPF_is_zero = ((AC_TCSPF == 0) + (AC_TCSPF == None))
         AC_exceeds_cooling_benchmark = np.where(
             TCSPF_is_zero,
-            (AC_AEER >= parameters(period).PDRS.AC.table_HVAC_1_4[product_class][cooling_capacity]),
-            (AC_TCSPF >= parameters(period).PDRS.AC.table_HVAC_1_3[product_class][cooling_capacity])
+            (AC_AEER >= parameters(period).PDRS.AC.table_HVAC_2_4[product_class][cooling_capacity]),
+            (AC_TCSPF >= parameters(period).PDRS.AC.table_HVAC_2_3[product_class][cooling_capacity])
             )
 
         return AC_exceeds_cooling_benchmark


### PR DESCRIPTION
# [DG22-2407] fix incorrect reference table and adjust test

## Summary
This pull request addresses the following functionality/fixes:
* Correct reference table in formula of variable `HVAC2_PDRSAug24_TCSPF_or_AEER_exceeds_ESS_benchmark`
* Adjust test

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2407

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None