### PR TITLE
D17 eligibility: add safety requirements

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D17_ESSJun24/D17_ESSJun24_installation_final_activity_eligibility.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D17_ESSJun24/D17_ESSJun24_installation_final_activity_eligibility.yaml
@@ -80,6 +80,17 @@
         True,
         False #not eligible
       ]
+    D17_ESSJun24_safety_requirement:
+      [
+        True,
+        False,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True
+      ]  
   output:
     D17_ESSJun24_replacement_final_activity_eligibility:
       [

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D17_ESSJun24/activity_eligibility/D17_ESSJun24_activity_eligibility_parameters.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D17_ESSJun24/activity_eligibility/D17_ESSJun24_activity_eligibility_parameters.py
@@ -97,3 +97,27 @@ class D17_ESSJun24_equipment_registered_IPART(Variable):
                                      o 60% when modelled in AS/NZ 4234 climate zone HP3-AU<br />
                                      o 60% when modelled in AS/NZ 4234 climate zone HP5-AU"""
     }
+
+
+class D17_ESSJun24_split_system(Variable):
+    value_type = bool
+    entity = Building
+    default_value = False
+    definition_period = ETERNITY
+    metadata = {
+      'display_question' : 'Is the replacement air source heat pump water heater a split system?',
+      'sorting' : 8,
+      'eligibility_clause' : """In ESS D17 Implementation Requirements Clause 4 it states that the where the replacement End-User Equipment is a split system with refrigerant flows between the evaporator and tank, safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations must be followed."""
+    }
+
+
+class D17_ESSJun24_safety_requirement(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+      'display_question' : 'Have safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations been followed for the installation?',
+      'sorting' : 9,
+      'eligibility_clause' : """In ESS F16 Implementation Requirements Clause 4 it states that the where the replacement End-User Equipment is a split system with refrigerant flows between the evaporator and tank, safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations must be followed."""
+    }

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D17_ESSJun24/activity_eligibility/D17_ESSJun24_eligibility.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D17_ESSJun24/activity_eligibility/D17_ESSJun24_eligibility.py
@@ -26,8 +26,9 @@ class D17_ESSJun24_replacement_final_activity_eligibility(Variable):
         new_equipment_installed = buildings('D17_ESSJun24_equipment_installed', period)
         qualified_install = buildings('D17_ESSJun24_installed_by_qualified_person', period)
         registered_IPART = buildings('D17_ESSJun24_equipment_registered_IPART', period)
+        safety_requirement = buildings('D17_ESSJun24_safety_requirement', period)
         
         end_formula =  ( equipment_replaced * ACP_engaged * minimum_payment *
-                        equipment_removed * new_equipment_installed * qualified_install * registered_IPART)
+                        equipment_removed * new_equipment_installed * qualified_install * registered_IPART * safety_requirement )
         
         return end_formula


### PR DESCRIPTION
# [DG22-2473] Add 2 new variables - UI required.

## Summary
This pull request addresses the following functionality/fixes:
* Add 2 new variable which will require UI. split_system and safety_requirement.
*  The variables split_system if answered "No" D17 Activity Requirements  satisfied. But if answered "Yes" then show safey_requirement question, then D17 Activity Requirements  satisfied. 
Miro for clear information. - https://miro.com/app/board/uXjVPXwFzQ0=/?moveToWidget=3458764621398509332&cot=14 

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2473

**Screenshots**
<img width="821" height="605" alt="image" src="https://github.com/user-attachments/assets/f4ce436e-cab5-4066-be38-cd195c765cc1" />

## Pre deployment tasks
- None

## Post deployment tasks
- None
