### PR TITLE
D19 eligibility: add safety requirements

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D19_ESSJun24/D19_ESSJun24_installation_final_activity_eligibility.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/D19_ESSJun24/D19_ESSJun24_installation_final_activity_eligibility.yaml
@@ -80,6 +80,17 @@
         True,
         False #not eligible
       ]
+    D19_ESSJun24_safety_requirement:
+      [
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True
+      ]
   output:
     D19_ESSJun24_replacement_final_activity_eligibility:
       [

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D19_ESSJun24/activity_eligibility/D19_ESSJun24_activity_eligibility_parameters.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D19_ESSJun24/activity_eligibility/D19_ESSJun24_activity_eligibility_parameters.py
@@ -107,7 +107,7 @@ class D19_ESSJun24_split_system(Variable):
     metadata = {
       'display_question' : 'Is the replacement air source heat pump water heater a split system?',
       'sorting' : 8,
-      'eligibility_clause' : """In ESS D19 Implementation Requirements Clause 4 it states that the where the replacement End-User Equipment is a split system with refrigerant flows between the evaporator and tank, safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations must be followed."""
+      'eligibility_clause' : """In ESS D19 Implementation Requirements Clause 4 it states that where the replacement End-User Equipment is a split system with refrigerant flows between the evaporator and tank, safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations must be followed."""
     }
 
 
@@ -119,5 +119,5 @@ class D19_ESSJun24_safety_requirement(Variable):
     metadata = {
       'display_question' : 'Have safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations been followed for the installation?',
       'sorting' : 9,
-      'eligibility_clause' : """In ESS D19 Implementation Requirements Clause 4 it states that the where the replacement End-User Equipment is a split system with refrigerant flows between the evaporator and tank, safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations must be followed."""
+      'eligibility_clause' : """In ESS D19 Implementation Requirements Clause 4 it states that where the replacement End-User Equipment is a split system with refrigerant flows between the evaporator and tank, safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations must be followed."""
     }    

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D19_ESSJun24/activity_eligibility/D19_ESSJun24_activity_eligibility_parameters.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D19_ESSJun24/activity_eligibility/D19_ESSJun24_activity_eligibility_parameters.py
@@ -97,3 +97,27 @@ class D19_ESSJun24_equipment_registered_IPART(Variable):
                                     • 60% when modelled in climate zone HP3-AU<br />
                                     • 60% when modelled in climate zone HP5-AU"""
     }
+
+
+class D19_ESSJun24_split_system(Variable):
+    value_type = bool
+    entity = Building
+    default_value = False
+    definition_period = ETERNITY
+    metadata = {
+      'display_question' : 'Is the replacement air source heat pump water heater a split system?',
+      'sorting' : 8,
+      'eligibility_clause' : """In ESS D19 Implementation Requirements Clause 4 it states that the where the replacement End-User Equipment is a split system with refrigerant flows between the evaporator and tank, safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations must be followed."""
+    }
+
+
+class D19_ESSJun24_safety_requirement(Variable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+      'display_question' : 'Have safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations been followed for the installation?',
+      'sorting' : 9,
+      'eligibility_clause' : """In ESS D19 Implementation Requirements Clause 4 it states that the where the replacement End-User Equipment is a split system with refrigerant flows between the evaporator and tank, safety requirements of AS/NZS 5149.3:2016 and manufacturer installation recommendations must be followed."""
+    }    

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D19_ESSJun24/activity_eligibility/D19_ESSJun24_eligibility.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/D19_ESSJun24/activity_eligibility/D19_ESSJun24_eligibility.py
@@ -26,8 +26,10 @@ class D19_ESSJun24_replacement_final_activity_eligibility(Variable):
         new_equipment_installed = buildings('D19_ESSJun24_equipment_installed', period)
         qualified_install = buildings('D19_ESSJun24_installed_by_qualified_person', period)
         registered_IPART = buildings('D19_ESSJun24_equipment_registered_IPART', period)
+        split_system = buildings('D19_ESSJun24_split_system', period)
+        safety_requirement = buildings('D19_ESSJun24_safety_requirement', period)
         
         end_formula =  ( equipment_replaced * ACP_engaged * minimum_payment *
-                        equipment_removed * new_equipment_installed * qualified_install * registered_IPART)
+                        equipment_removed * new_equipment_installed * qualified_install * registered_IPART * safety_requirement )
         
         return end_formula


### PR DESCRIPTION
# [DG22-2475] add 2 new variables (UI required)
## Summary
This pull request addresses the following functionality/fixes:
* Added 2 new variables  split_system and safety_requirement - UI required
* UI change for only show question 9 if in Q8 "Yes". If the user changes the answer to "No", the result is not eligible (D19 Activity Requirements  satisfied).
Link: https://miro.com/app/board/uXjVPXwFzQ0=/?moveToWidget=3458764621398801573&cot=14

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2475

**Screenshots**
- None 

## Pre deployment tasks
- None
## Post deployment tasks
- None



[DG22-2475]: https://essnsw.atlassian.net/browse/DG22-2475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ