### PR TITLE
[DG22-2477] - D5/SYS2 certificates UI: Maximum Tested Input Power instead of Nameplate Input Power

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS2_PDRSAug24/SYS2_PDRSAug24_ESC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS2_PDRSAug24/SYS2_PDRSAug24_ESC_calculation.yaml
@@ -2,7 +2,7 @@
   period: 2024
   absolute_error_margin: 0
   input:
-    SYS2_PDRSAug24_nameplate_input_power:
+    SYS2_PDRSAug24_maximum_tested_input_power:
       [
         900,
         1400,
@@ -55,7 +55,7 @@
   period: 2024
   absolute_error_margin: 0.1
   input:
-    SYS2_PDRSAug24_nameplate_input_power:
+    SYS2_PDRSAug24_maximum_tested_input_power:
       [
         0,    #baseline PAEC 1300
         1000, #baseline PAEC 1300
@@ -140,7 +140,7 @@
         9.11,
         -5
       ]
-    SYS2_PDRSAug24_nameplate_input_power:
+    SYS2_PDRSAug24_maximum_tested_input_power:
       [
         0,
         0,
@@ -190,7 +190,7 @@
   period: 2024
   absolute_error_margin: 0.1
   input: 
-    SYS2_PDRSAug24_nameplate_input_power:
+    SYS2_PDRSAug24_maximum_tested_input_power:
       [
         0
       ]

--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS2_PDRSAug24/SYS2_PDRSAug24_PRC_calculation.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/SYS2_PDRSAug24/SYS2_PDRSAug24_PRC_calculation.yaml
@@ -55,7 +55,7 @@
   period: 2024
   absolute_error_margin: 0
   input:
-    SYS2_PDRSAug24_nameplate_input_power:
+    SYS2_PDRSAug24_maximum_tested_input_power:
       [
         900,
         1400,
@@ -97,7 +97,7 @@
         2,
         2
       ]
-    SYS2_PDRSAug24_nameplate_input_power:
+    SYS2_PDRSAug24_maximum_tested_input_power:
       [
         0,
         1000,
@@ -180,7 +180,7 @@
         1.05,
         1.05
       ]
-    SYS2_PDRSAug24_nameplate_input_power:
+    SYS2_PDRSAug24_maximum_tested_input_power:
       [
         1,
         0,
@@ -230,7 +230,7 @@
         1.05,
         1.05
       ]
-    SYS2_PDRSAug24_nameplate_input_power:
+    SYS2_PDRSAug24_maximum_tested_input_power:
       [
         1990,
         750,
@@ -267,7 +267,7 @@
         2372,
         2800
       ]
-    SYS2_PDRSAug24_nameplate_input_power:
+    SYS2_PDRSAug24_maximum_tested_input_power:
       [
         1990,
         750,

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2_PDRSAug24/certificate_estimation/SYS2_PDRSAug24_ESC_calculation.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2_PDRSAug24/certificate_estimation/SYS2_PDRSAug24_ESC_calculation.py
@@ -51,18 +51,18 @@ class SYS2_PDRSAug24_energy_savings(Variable):
 
     def formula(buildings, period, parameters):
         #Nameplate input power
-        nameplate_input_power = buildings('SYS2_PDRSAug24_nameplate_input_power', period)
+        maximum_tested_input_power = buildings('SYS2_PDRSAug24_maximum_tested_input_power', period)
 
         #PAEC
         PAEC = buildings('SYS2_PDRSAug24_projected_annual_energy_consumption', period)
 
         #PAEC baseline
-        nameplate_input_power_to_check = np.select(
+        maximum_tested_input_power_to_check = np.select(
             [
-                (nameplate_input_power <= 1000),
-                (nameplate_input_power > 1000) * (nameplate_input_power <= 1500),
-                (nameplate_input_power > 1500) * (nameplate_input_power <= 2000),
-                (nameplate_input_power > 2000),
+                (maximum_tested_input_power <= 1000),
+                (maximum_tested_input_power > 1000) * (maximum_tested_input_power <= 1500),
+                (maximum_tested_input_power > 1500) * (maximum_tested_input_power <= 2000),
+                (maximum_tested_input_power > 2000),
             ],
             [
                 'less_than_or_equal_to_1000w',
@@ -71,7 +71,7 @@ class SYS2_PDRSAug24_energy_savings(Variable):
                 'greater_than_2000w'
             ])
 
-        PAEC_baseline = parameters(period).ESS.HEER.table_D5_1_PDRSAug24.baseline_PAEC[nameplate_input_power_to_check]
+        PAEC_baseline = parameters(period).ESS.HEER.table_D5_1_PDRSAug24.baseline_PAEC[maximum_tested_input_power_to_check]
 
         #deemed activity electricity savings
         lifetime = 10
@@ -123,12 +123,12 @@ class SYS2_PDRSAug24_ESC_calculation(Variable):
     def formula(buildings, period, parameters):
         electricity_savings = buildings('SYS2_PDRSAug24_electricity_savings', period)
         electricity_certificate_conversion_factor = 1.06
-        nameplate_input_power = buildings('SYS2_PDRSAug24_nameplate_input_power', period)
+        maximum_tested_input_power = buildings('SYS2_PDRSAug24_maximum_tested_input_power', period)
         daily_run_time = buildings('SYS2_PDRSAug24_daily_run_time', period)
         PAEC = buildings('SYS2_PDRSAug24_projected_annual_energy_consumption', period)
 
         #check if all three values are zero, and if they are, return zero certificates
-        zero_product_data = (nameplate_input_power == 0) * (daily_run_time == 0) * (PAEC == 0)
+        zero_product_data = (maximum_tested_input_power == 0) * (daily_run_time == 0) * (PAEC == 0)
 
         result = (electricity_savings * electricity_certificate_conversion_factor)
         result_has_data = np.select(

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2_PDRSAug24/certificate_estimation/SYS2_PDRSAug24_ESC_variables.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2_PDRSAug24/certificate_estimation/SYS2_PDRSAug24_ESC_variables.py
@@ -22,15 +22,14 @@ class SYS2_PDRSAug24_PDRS__postcode(Variable):
         'sorting' : 1
     }
 
-
-class SYS2_PDRSAug24_nameplate_input_power(Variable):
+class SYS2_PDRSAug24_maximum_tested_input_power(Variable):
     value_type = float
     entity = Building
     definition_period = ETERNITY
     metadata = {
         'variable-type' : 'input',
-        'label': 'Nameplate Input Power (w)',
-        'display_question' : 'The input power of the new or replacement pool pump as recorded in the GEMS Registry',
+        'label': 'Maximum Tested Input Power (w)',
+        'display_question' : 'The input power of the new or replacement pool pump as recorded in the GEMS Registry, also known as “High” in the Registry',
         'sorting' : 2
     }
 
@@ -68,14 +67,14 @@ class SYS2_PDRSAug24_PAEC_baseline(Variable):
     }
 
     def formula(buildings, period, parameters):
-        nameplate_input_power = buildings('SYS2_PDRSAug24_nameplate_input_power', period)
+        maximum_tested_input_power = buildings('SYS2_PDRSAug24_maximum_tested_input_power', period)
 
-        nameplate_input_power_to_check = np.select(
+        maximum_tested_input_power_to_check = np.select(
             [
-                (nameplate_input_power <= 1000),
-                (nameplate_input_power > 1000) * (nameplate_input_power <= 1500),
-                (nameplate_input_power > 1500) * (nameplate_input_power <= 2000),
-                (nameplate_input_power > 2000),
+                (maximum_tested_input_power <= 1000),
+                (maximum_tested_input_power > 1000) * (maximum_tested_input_power <= 1500),
+                (maximum_tested_input_power > 1500) * (maximum_tested_input_power <= 2000),
+                (maximum_tested_input_power > 2000),
             ],
             [
                 'less_than_or_equal_to_1000w',
@@ -84,5 +83,5 @@ class SYS2_PDRSAug24_PAEC_baseline(Variable):
                 'greater_than_2000w'
             ])
 
-        PAEC_baseline = parameters(period).ESS.HEER.table_D5_1_PDRSAug24.baseline_PAEC[nameplate_input_power_to_check]
+        PAEC_baseline = parameters(period).ESS.HEER.table_D5_1_PDRSAug24.baseline_PAEC[maximum_tested_input_power_to_check]
         return PAEC_baseline

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2_PDRSAug24/certificate_estimation/SYS2_PDRSAug24_PRC_calculation.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2_PDRSAug24/certificate_estimation/SYS2_PDRSAug24_PRC_calculation.py
@@ -46,14 +46,14 @@ class SYS2_PDRSAug24_peak_demand_annual_savings(Variable):
         input_power = PAEC / (365 * DRT)
 
         #nameplate input power
-        nameplate_input_power = buildings('SYS2_PDRSAug24_nameplate_input_power', period)
+        maximum_tested_input_power = buildings('SYS2_PDRSAug24_maximum_tested_input_power', period)
 
-        nameplate_input_power_to_check = np.select(
+        maximum_tested_input_power_to_check = np.select(
             [
-                (nameplate_input_power <= 1000),
-                (nameplate_input_power > 1000) * (nameplate_input_power <= 1500),
-                (nameplate_input_power > 1500) * (nameplate_input_power <= 2000),
-                (nameplate_input_power > 2000),
+                (maximum_tested_input_power <= 1000),
+                (maximum_tested_input_power > 1000) * (maximum_tested_input_power <= 1500),
+                (maximum_tested_input_power > 1500) * (maximum_tested_input_power <= 2000),
+                (maximum_tested_input_power > 2000),
             ],
             [
                 'less_than_or_equal_to_1000w',
@@ -63,7 +63,7 @@ class SYS2_PDRSAug24_peak_demand_annual_savings(Variable):
             ])
 
         #baseline input power
-        baseline_input_power = parameters(period).PDRS.pool_pumps.table_sys2_1_PDRSAug24['baseline_input_power'][nameplate_input_power_to_check]
+        baseline_input_power = parameters(period).PDRS.pool_pumps.table_sys2_1_PDRSAug24['baseline_input_power'][maximum_tested_input_power_to_check]
 
         #baseline peak adjustment factor
         baseline_peak_adjustment_factor = parameters(period).PDRS.table_A4_PDRSAug24_adjustment_factors['baseline_peak_adjustment']['SYS2']
@@ -124,12 +124,12 @@ class SYS2_PDRSAug24_PRC_calculation(Variable):
         peak_demand_capacity = buildings('SYS2_PDRSAug24_peak_demand_reduction_capacity', period)
         network_loss_factor = buildings('SYS2_PDRSAug24_get_network_loss_factor_by_postcode', period)
         kw_to_0_1kw = 10
-        nameplate_input_power = buildings('SYS2_PDRSAug24_nameplate_input_power', period)
+        maximum_tested_input_power = buildings('SYS2_PDRSAug24_maximum_tested_input_power', period)
         daily_run_time = buildings('SYS2_PDRSAug24_daily_run_time', period)
         PAEC = buildings('SYS2_PDRSAug24_projected_annual_energy_consumption', period)
 
         #check if all three values are zero, and if they are, return zero certificates
-        zero_product_data = (nameplate_input_power == 0) * (daily_run_time == 0) * (PAEC == 0)
+        zero_product_data = (maximum_tested_input_power == 0) * (daily_run_time == 0) * (PAEC == 0)
 
         result = (peak_demand_capacity * network_loss_factor * kw_to_0_1kw)
         result_has_data = np.select(

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2_PDRSAug24/certificate_estimation/SYS2_PDRSAug24_PRC_variables.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/SYS2_PDRSAug24/certificate_estimation/SYS2_PDRSAug24_PRC_variables.py
@@ -27,14 +27,14 @@ class SYS2_PDRSAug24_baseline_input_power(Variable):
     definition_period = ETERNITY
 
     def formula(buildings, period, parameters):
-        nameplate_input_power = buildings('SYS2_PDRSAug24_nameplate_input_power', period)
+        maximum_tested_input_power = buildings('SYS2_PDRSAug24_maximum_tested_input_power', period)
 
-        nameplate_input_power_to_check = np.select(
+        maximum_tested_input_power_to_check = np.select(
             [
-                (nameplate_input_power <= 1000),
-                (nameplate_input_power > 1000) * (nameplate_input_power <= 1500),
-                (nameplate_input_power > 1500) * (nameplate_input_power <= 2000),
-                (nameplate_input_power > 2000),
+                (maximum_tested_input_power <= 1000),
+                (maximum_tested_input_power > 1000) * (maximum_tested_input_power <= 1500),
+                (maximum_tested_input_power > 1500) * (maximum_tested_input_power <= 2000),
+                (maximum_tested_input_power > 2000),
             ],
             [
                 'less_than_or_equal_to_1000w',
@@ -43,7 +43,7 @@ class SYS2_PDRSAug24_baseline_input_power(Variable):
                 'greater_than_2000w'
             ])
 
-        baseline_input_power = parameters(period).PDRS.pool_pumps.table_sys2_1_PDRSAug24.baseline_input_power[nameplate_input_power_to_check]
+        baseline_input_power = parameters(period).PDRS.pool_pumps.table_sys2_1_PDRSAug24.baseline_input_power[maximum_tested_input_power_to_check]
         return baseline_input_power
 
 


### PR DESCRIPTION
## Summary
This pull request addresses the following functionality/fixes:
* change nameplater input power variable to maximum tested input power
* adjust test

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2477

**Screenshots**
- None 

## Pre deployment tasks
- None

## Post deployment tasks
- None