### PR TITLE
BESS2 Eligibility updated_ test passing

### DIFF
--- a/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/BESS2_V5Nov24/BESS2_V5Nov24_installation_final_activity_eligibility.yaml
+++ b/openfisca_nsw_safeguard/tests/ESS_PDRS_Estimator/BESS2_V5Nov24/BESS2_V5Nov24_installation_final_activity_eligibility.yaml
@@ -14,10 +14,27 @@
         True,
         True,
         True,
+        True,
         False
       ]
     BESS2_V5Nov24_existing_solar_battery:
       [
+        True,
+        True,
+        False, #not eligible
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        True,
+        False
+      ]
+    BESS2_V5Nov24_BCA_class_1:
+      [
+        True,
         True,
         True,
         False, #not eligible
@@ -35,6 +52,7 @@
         True,
         True,
         True,
+        True,
         False, #not eligible
         True,
         True,
@@ -43,9 +61,10 @@
         True,
         True,
         False
-      ]
-    BESS2_V5Nov24_engaged_ACP:
+      ]      
+    BESS2_V5Nov24_approved_battery_list:
       [
+        True,
         True,
         True,
         True,
@@ -60,6 +79,7 @@
       ]
     BESS2_V5Nov24_battery_capacity:
       [
+        True,
         True,
         True,
         True,
@@ -80,6 +100,7 @@
         True,
         True,
         True,
+        True,
         False, #not eligible
         True,
         True,
@@ -88,6 +109,7 @@
       ]
     BESS2_V5Nov24_equipment_warranty:
       [
+        True,
         True,
         True,
         True,
@@ -110,16 +132,18 @@
         True,
         True,
         True,
+        True,
         False, #not eligible
         True,
         False
       ]
-    BESS2_V5Nov24_approved_battery_list:
+    BESS2_V5Nov24_engaged_ACP:
       [
         True,
         True,
         True,
-        True, 
+        True,
+        True,
         True,
         True,
         True,
@@ -127,11 +151,12 @@
         True,
         False, #not eligible
         False
-      ]
+      ]      
   output:
     BESS2_V5Nov24_installation_final_activity_eligibility:
       [
         True,  #all true
+        False,
         False,
         False,
         False,

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_activity_eligibility_parameters.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_activity_eligibility_parameters.py
@@ -14,7 +14,7 @@ class BESS2_V5Nov24_demand_response_contract(BaseVariable):
     metadata = {
         'display_question' : 'Have you connected a solar battery to a virtual power plant?',
         'sorting' : 1,
-        'eligibility_clause' : """The PDRS BESS2 activity is onboard a behind the meter residential battery energy storage system with a demand response aggregator."""
+        'eligibility_clause' : """The PDRS BESS2 activity is to onboard a behind the meter residential battery energy storage system with a demand response aggregator."""
     }
 
 
@@ -30,6 +30,19 @@ class BESS2_V5Nov24_existing_solar_battery(BaseVariable):
     }
     
 
+class BESS2_V5Nov24_BCA_class_1(BaseVariable):
+    value_type = bool
+    entity = Building
+    default_value = True
+    definition_period = ETERNITY
+    metadata = {
+        'display_question' : 'Is the Site a BCA Class 1 Building or Small Business Site, as evidenced to the satisfaction of the Scheme Administrator?',
+        'sorting' : 3,
+        'eligibility_clause' : """In PDRS Clause 9.1.1The Peak Demand Reduction Capacity for an Implementation is to be calculated using Equation 2c provided that:<br />
+                                  (a) the Site is a BCA Class 1 Building or Small Business Site, as evidenced to the satisfaction of the Scheme Administrator."""
+    }
+
+
 class BESS2_V5Nov24_life_support_equipment(BaseVariable):
     value_type = bool
     entity = Building
@@ -37,21 +50,20 @@ class BESS2_V5Nov24_life_support_equipment(BaseVariable):
     definition_period = ETERNITY
     metadata = {
         'display_question' : 'Are you aware that demand response is not allowed where there is life support equipment?',
-        'sorting' : 3,
-        'eligibility_clause' : """In PDRS BESS2 Eligibility Requirements Clause 3 it states that there must not be any Life Support Equipment used at the Site."""
+        'sorting' : 4,
+        'eligibility_clause' : """In PDRS BESS2 Eligibility Requirements Clause 2 it states that there must not be any Life Support Equipment used at the Site."""
     }
 
 
-class BESS2_V5Nov24_engaged_ACP(BaseVariable):
+class BESS2_V5Nov24_approved_battery_list(BaseVariable):
     value_type = bool
     entity = Building
     default_value = True
     definition_period = ETERNITY
     metadata = {
-        'display_question' : 'Will an Accredited Certificate Provider be engaged before the implementation date?',
-        'sorting' : 4,
-        'eligibility_clause' : """In PDRS Clause 6 it states that an Accredited Certificate Provider may only create Peak Reduction Certificates for a Recognised Peak Activity if:<br />
-                                  (a) the Accredited Certificate Provider is accredited in respect of the activity on or before the Implementation Date for the activity."""
+        'display_question' : 'Is the battery a registered product on the Clean Energy Council approved battery list?',
+        'sorting' : 5,
+        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 1 it states that the End-User Equipment must be listed on the approved product list specified by the Scheme Administrator."""
     }
 
 
@@ -61,8 +73,8 @@ class BESS2_V5Nov24_battery_capacity(BaseVariable):
     default_value = True
     definition_period = ETERNITY
     metadata = {
-        'display_question' : 'Is the battery capacity between 2- 50kWh?',
-        'sorting' : 5,
+        'display_question' : 'Is the battery capacity between 2- 50 kWh?',
+        'sorting' : 6,
         'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 2 it states that the End-User Equipment must have a Usable Battery Capacity greater than 2 kWh and less than or equal to 50 kWh as recorded on the approved product list specified by the Scheme Administrator."""
     }
 
@@ -74,7 +86,7 @@ class BESS2_V5Nov24_length_battery_warranty(BaseVariable):
     definition_period = ETERNITY
     metadata = {
         'display_question' : 'Does the battery have a remaining warranty of at least 6 years?',
-        'sorting' : 6,
+        'sorting' : 7,
         'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 3 it states that each item of End-User Equipment must have a minimum 6 years remaining on the warranty."""
     }
 
@@ -85,8 +97,8 @@ class BESS2_V5Nov24_equipment_warranty(BaseVariable):
     default_value = True
     definition_period = ETERNITY
     metadata = {
-        'display_question' : 'Does participation in the activity affect the validity of the End-User Equipment warranty?',
-        'sorting' : 7,
+        'display_question' : 'Does participation in the activity avoid voiding or diminishing the End-User Equipment warranty?',
+        'sorting' : 8,
         'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 4 it states that participation in the activity must not void or diminish the End-User Equipment warranty."""
     }
 
@@ -98,18 +110,19 @@ class BESS2_V5Nov24_internet_connectable(BaseVariable):
     definition_period = ETERNITY
     metadata = {
         'display_question' : 'Is the battery internet connectable?',
-        'sorting' : 8,
+        'sorting' : 9,
         'eligibility_clause' : """In PDRS BESS2 Implementation Requirements Clause 1 it states that the internet connection and Demand Response Aggregator control of the End-User Equipment must be demonstrated to be operational to the satisfaction of the Scheme Administrator."""
     }
 
 
-class BESS2_V5Nov24_approved_battery_list(BaseVariable):
+class BESS2_V5Nov24_engaged_ACP(BaseVariable):
     value_type = bool
     entity = Building
     default_value = True
     definition_period = ETERNITY
     metadata = {
-        'display_question' : 'Is the battery a registered product on the Clean Energy Council approved battery list?',
-        'sorting' : 9,
-        'eligibility_clause' : """In PDRS BESS2 Equipment Requirements Clause 1 it states that the End-User Equipment must be listed on the approved product list specified by the Scheme Administrator."""
+        'display_question' : 'Will an Accredited Certificate Provider be engaged before the implementation date?',
+        'sorting' : 10,
+        'eligibility_clause' : """In PDRS Clause 6 it states that an Accredited Certificate Provider may only create Peak Reduction Certificates for a Recognised Peak Activity if:<br />
+                                  (a) the Accredited Certificate Provider is accredited in respect of the activity on or before the Implementation Date for the activity."""
     }

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_eligibility.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_eligibility.py
@@ -20,16 +20,17 @@ class BESS2_V5Nov24_installation_final_activity_eligibility(BaseVariable):
     def formula(buildings, period, parameter):
         demand_response_contract = buildings('BESS2_V5Nov24_demand_response_contract', period)
         existing_solar_battery = buildings('BESS2_V5Nov24_existing_solar_battery', period)
+        BCA_class_1 = buildings('BESS2_V5Nov24_BCA_class_1', period)
         life_support_equipment = buildings('BESS2_V5Nov24_life_support_equipment', period)
-        ACP_engaged = buildings('BESS2_V5Nov24_engaged_ACP', period)
+        approved_battery_list = buildings('BESS2_V5Nov24_approved_battery_list', period)
         battery_capacity = buildings('BESS2_V5Nov24_battery_capacity', period)
         battery_warranty_length = buildings('BESS2_V5Nov24_length_battery_warranty', period)
         equipment_warranty = buildings('BESS2_V5Nov24_equipment_warranty', period)
         battery_internet_connectable = buildings('BESS2_V5Nov24_internet_connectable', period)
-        approved_battery_list = buildings('BESS2_V5Nov24_approved_battery_list', period)
+        ACP_engaged = buildings('BESS2_V5Nov24_engaged_ACP', period)
 
-        end_formula = (demand_response_contract * existing_solar_battery * life_support_equipment *
-                       ACP_engaged * battery_capacity * battery_warranty_length * equipment_warranty * 
-                       battery_internet_connectable * approved_battery_list)
+        end_formula = (demand_response_contract * existing_solar_battery * BCA_class_1 * life_support_equipment * 
+                       approved_battery_list * battery_capacity * battery_warranty_length * equipment_warranty * 
+                       battery_internet_connectable * ACP_engaged)
 
         return end_formula


### PR DESCRIPTION
# feature/DG22-2740-BESS2-Eligibility- Updated 27/05/26
## Summary
This pull request addresses the following functionality/fixes:
* See ticket for 2740 for full review. 
*  Q3 - Clause update = clause number should be 2 not 3.
* Update Question 7 - new label - Does participation in the activity avoid voiding or diminishing the End-User Equipment warranty?
* 	Q1 - add "to" in clause 
	Q5 - label - space bar between 50kWh = 50 kWh
	Q9 - updated the soring order, from the last question it now sits in q5 spot. Push everything else down.
* Q4 - updated the sorting order - put "Will an Accredited Certificate Provider be engaged before the implementation date?" as last question 
* New question added BCA Class 1


## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2740

**Screenshots**
- None 

## Pre deployment tasks
- None
## Post deployment tasks
- None