### PR TITLE
DG22-2853 - BESS2: remove word 'solar' from two Eligibility questions

### DIFF
--- a/.github/workflows/openfisca_azure_vm(uat).yml
+++ b/.github/workflows/openfisca_azure_vm(uat).yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           docker compose exec app make test
 
-  deploy:
+  build:
     needs: test
     name: Build
     runs-on: ubuntu-latest

--- a/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_activity_eligibility_parameters.py
+++ b/openfisca_nsw_safeguard/variables/ESS_PDRS_Estimator/BESS2_V5Nov24/activity_eligibility/BESS2_V5Nov24_activity_eligibility_parameters.py
@@ -12,7 +12,7 @@ class BESS2_V5Nov24_demand_response_contract(BaseVariable):
     default_value = True
     definition_period = ETERNITY
     metadata = {
-        'display_question' : 'Have you connected a solar battery to a virtual power plant?',
+        'display_question' : 'Have you connected a battery to a virtual power plant?',
         'sorting' : 1,
         'eligibility_clause' : """The PDRS BESS2 activity is to onboard a behind the meter residential battery energy storage system with a demand response aggregator."""
     }
@@ -24,7 +24,7 @@ class BESS2_V5Nov24_existing_solar_battery(BaseVariable):
     default_value = True
     definition_period = ETERNITY
     metadata = {
-        'display_question' : 'Is there a solar battery already installed at this address?',
+        'display_question' : 'Is there a battery already installed at this address?',
         'sorting' : 2,
         'eligibility_clause' : """In PDRS BESS2 Eligibility Requirements Clause 1 it states that there must be an existing Battery Energy Storage System installed at the National Metering Identifier(s)."""
     }


### PR DESCRIPTION
## Summary

This pull request addresses the following functionality/fixes:
* Remove word 'solar' in Eligibillity quesitons
* Rename workflow step in UAT

## Links and resources
**Links**
- Jira ticket: https://essnsw.atlassian.net/browse/DG22-2853

**Screenshots**
- None

## Pre deployment tasks
- None

## Post deployment tasks
- None